### PR TITLE
Auto-advance the music queue when a track finishes (#8)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,10 +65,11 @@ A skill declares `requires={"voice"}`; the
 whose `Capabilities` advertise that port. On a voice-less platform the skill is
 simply never exposed.
 
-> **Known limitation (deliberate):** `VoicePort` has no "track finished"
-> callback, so the music queue advances on an explicit `/music skip` or `/music
-> stop`, not automatically when a track ends. Adding a finished-callback to the
-> port is an additive follow-up that doesn't change the boundary.
+`VoicePort.play` accepts an optional `on_finished` callback; the Discord adapter
+invokes it (via the player's `after` hook, hopped back onto the event loop) when
+a track ends on its own, so the music queue **auto-advances**. The skill guards
+against stale callbacks with a per-conversation play token, so an explicit
+`/music skip` or `/music stop` never double-advances.
 
 ## Rendering is per-platform
 

--- a/petbot/core/skills/music_skill.py
+++ b/petbot/core/skills/music_skill.py
@@ -6,9 +6,11 @@ transport is delegated to the :class:`~petbot.core.skills.ports.VoicePort` the
 adapter injects via ``ctx.voice``. The skill therefore declares
 ``requires={"voice"}`` and is only offered on frontends that supply that port.
 
-Known limitation: :class:`VoicePort` has no "track finished" callback, so the
-queue advances on an explicit ``skip``/``stop`` rather than automatically. This
-is documented in ``docs/architecture.md`` as a deliberate, additive follow-up.
+The queue **auto-advances**: each track is started with an ``on_finished``
+callback that plays the next queued track when the current one ends on its own.
+A per-conversation ``play_token`` guards against stale callbacks — an explicit
+``skip``/``stop`` bumps the token, so the finished-callback fired by tearing
+down the old track is recognised as superseded and ignored (no double-advance).
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from typing import Any, ClassVar
 
 from petbot.core.skills.base import Skill
 from petbot.core.skills.context import SkillContext, SkillResult
+from petbot.core.skills.ports import TrackFinishedCallback, VoicePort
 
 #: Skip votes required (besides the requester, who may always self-skip).
 SKIP_THRESHOLD = 3
@@ -42,6 +45,9 @@ class ConversationMusic:
     current: Track | None = None
     skip_votes: set[str] = field(default_factory=set)
     volume: float = 0.6
+    # Bumped whenever playback changes by an explicit action; lets a finished
+    # callback detect that it has been superseded.
+    play_token: int = 0
 
 
 class MusicSkill(Skill):
@@ -95,12 +101,41 @@ class MusicSkill(Skill):
         if action == "skip":
             return await self._skip(ctx, state)
         if action == "stop":
-            return await self._stop(ctx, state)
+            return await self._stop(ctx.voice, state)
         if action == "queue":
             return self._show_queue(state)
         if action == "volume":
             return self._set_volume(args, state)
         return SkillResult.failure(f"Unknown music action: {action!r}.")
+
+    async def _start(self, state: ConversationMusic, voice: VoicePort, track: Track) -> None:
+        """Make ``track`` the current track and begin playing it."""
+        state.current = track
+        state.skip_votes.clear()
+        state.play_token += 1
+        token = state.play_token
+        await voice.play(
+            track.source_url,
+            volume=state.volume,
+            on_finished=self._on_finished(state, voice, token),
+        )
+
+    def _on_finished(
+        self, state: ConversationMusic, voice: VoicePort, token: int
+    ) -> TrackFinishedCallback:
+        """Build the callback that advances the queue when a track ends naturally."""
+
+        async def _advance_on_end() -> None:
+            if token != state.play_token:
+                # Superseded by an explicit skip/stop or a newer track.
+                return
+            if state.queue:
+                await self._start(state, voice, state.queue.popleft())
+            else:
+                state.current = None
+                state.play_token += 1
+
+        return _advance_on_end
 
     async def _play(
         self, args: Mapping[str, Any], ctx: SkillContext, state: ConversationMusic
@@ -118,9 +153,7 @@ class MusicSkill(Skill):
             state.queue.append(track)
             return SkillResult.message(f"Enqueued **{query}** (position {len(state.queue)}).")
 
-        state.current = track
-        state.skip_votes.clear()
-        await ctx.voice.play(track.source_url, volume=state.volume)
+        await self._start(state, ctx.voice, track)
         return SkillResult.message(f"▶️ Now playing **{query}**.")
 
     async def _skip(self, ctx: SkillContext, state: ConversationMusic) -> SkillResult:
@@ -137,25 +170,27 @@ class MusicSkill(Skill):
                 votes = len(state.skip_votes)
                 return SkillResult.message(f"Skip vote added [{votes}/{SKIP_THRESHOLD}].")
 
-        return await self._advance(ctx, state)
+        return await self._advance(state, ctx.voice)
 
-    async def _advance(self, ctx: SkillContext, state: ConversationMusic) -> SkillResult:
-        assert ctx.voice is not None
-        state.skip_votes.clear()
+    async def _advance(self, state: ConversationMusic, voice: VoicePort) -> SkillResult:
         if state.queue:
-            state.current = state.queue.popleft()
-            await ctx.voice.play(state.current.source_url, volume=state.volume)
-            return SkillResult.message(f"⏭️ Skipped. Now playing **{state.current.source_url}**.")
+            next_track = state.queue.popleft()
+            # _start bumps play_token, so the finished-callback fired by tearing
+            # down the current track is recognised as stale and ignored.
+            await self._start(state, voice, next_track)
+            return SkillResult.message(f"⏭️ Skipped. Now playing **{next_track.source_url}**.")
         state.current = None
-        await ctx.voice.stop()
+        state.skip_votes.clear()
+        state.play_token += 1  # invalidate the pending finished-callback
+        await voice.stop()
         return SkillResult.message("⏭️ Skipped. Nothing left in the queue.")
 
-    async def _stop(self, ctx: SkillContext, state: ConversationMusic) -> SkillResult:
-        assert ctx.voice is not None
+    async def _stop(self, voice: VoicePort, state: ConversationMusic) -> SkillResult:
         state.queue.clear()
         state.current = None
         state.skip_votes.clear()
-        await ctx.voice.stop()
+        state.play_token += 1  # invalidate the pending finished-callback
+        await voice.stop()
         return SkillResult.message("⏹️ Stopped and cleared the queue.")
 
     def _show_queue(self, state: ConversationMusic) -> SkillResult:

--- a/petbot/core/skills/ports.py
+++ b/petbot/core/skills/ports.py
@@ -11,7 +11,12 @@ just by matching the shape, with no import back into the core.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+#: Invoked (with no arguments) when a track finishes playing on its own, so the
+#: caller can advance a queue. Adapters schedule it on the event loop.
+TrackFinishedCallback = Callable[[], Awaitable[None]]
 
 
 @runtime_checkable
@@ -26,8 +31,18 @@ class VoicePort(Protocol):
         """Connect to (or move to) the given voice channel."""
         ...
 
-    async def play(self, source_url: str, *, volume: float = 0.6) -> None:
-        """Begin playing ``source_url`` at ``volume`` (0.0-1.0)."""
+    async def play(
+        self,
+        source_url: str,
+        *,
+        volume: float = 0.6,
+        on_finished: TrackFinishedCallback | None = None,
+    ) -> None:
+        """Begin playing ``source_url`` at ``volume`` (0.0-1.0).
+
+        If ``on_finished`` is given, it is awaited once the track ends *on its
+        own*. It is not invoked when playback is replaced or stopped explicitly.
+        """
         ...
 
     async def stop(self) -> None:

--- a/petbot/frontends/discord/voice.py
+++ b/petbot/frontends/discord/voice.py
@@ -12,6 +12,8 @@ import asyncio
 import discord
 import yt_dlp
 
+from petbot.core.skills.ports import TrackFinishedCallback
+
 # Reconnect options keep streamed sources alive across transient network blips.
 _FFMPEG_BEFORE_OPTIONS = "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
 _YTDL_OPTIONS = {
@@ -53,14 +55,34 @@ class DiscordVoicePort:
         if isinstance(channel, discord.VoiceChannel | discord.StageChannel):
             await channel.connect()
 
-    async def play(self, source_url: str, *, volume: float = 0.6) -> None:
+    async def play(
+        self,
+        source_url: str,
+        *,
+        volume: float = 0.6,
+        on_finished: TrackFinishedCallback | None = None,
+    ) -> None:
         voice_client = await self._ensure_connected()
         stream_url = await asyncio.to_thread(_extract_stream_url, source_url)
         source = discord.FFmpegPCMAudio(stream_url, before_options=_FFMPEG_BEFORE_OPTIONS)
         transformed = discord.PCMVolumeTransformer(source, volume=volume)
+
+        loop = asyncio.get_running_loop()
+
+        def _after(error: Exception | None) -> None:
+            # Runs in discord.py's player thread; hop back onto the event loop to
+            # await the (async) finished callback.
+            if on_finished is None:
+                return
+
+            async def _runner() -> None:
+                await on_finished()
+
+            asyncio.run_coroutine_threadsafe(_runner(), loop)
+
         if voice_client.is_playing():
             voice_client.stop()
-        voice_client.play(transformed)
+        voice_client.play(transformed, after=_after)
 
     async def stop(self) -> None:
         voice_client = self._guild.voice_client

--- a/tests/test_music_skill.py
+++ b/tests/test_music_skill.py
@@ -5,21 +5,34 @@ from __future__ import annotations
 from conftest import make_context
 
 from petbot.core.skills.music_skill import SKIP_THRESHOLD, MusicSkill
+from petbot.core.skills.ports import TrackFinishedCallback
 
 
 class FakeVoicePort:
-    """A minimal in-memory :class:`VoicePort` for tests."""
+    """A minimal in-memory :class:`VoicePort` for tests.
+
+    Records what was played and the latest ``on_finished`` callback so a test can
+    simulate a track ending naturally via :meth:`finish_current`.
+    """
 
     def __init__(self) -> None:
         self.played: list[tuple[str, float]] = []
         self.stop_count = 0
         self._playing = False
+        self._on_finished: TrackFinishedCallback | None = None
 
     async def join(self, channel_id: str) -> None:  # pragma: no cover - unused by skill
         pass
 
-    async def play(self, source_url: str, *, volume: float = 0.6) -> None:
+    async def play(
+        self,
+        source_url: str,
+        *,
+        volume: float = 0.6,
+        on_finished: TrackFinishedCallback | None = None,
+    ) -> None:
         self.played.append((source_url, volume))
+        self._on_finished = on_finished
         self._playing = True
 
     async def stop(self) -> None:
@@ -28,6 +41,17 @@ class FakeVoicePort:
 
     def is_playing(self) -> bool:
         return self._playing
+
+    @property
+    def pending_callback(self) -> TrackFinishedCallback | None:
+        return self._on_finished
+
+    async def finish_current(self) -> None:
+        """Simulate the current track ending on its own."""
+        callback = self._on_finished
+        self._playing = False
+        if callback is not None:
+            await callback()
 
 
 async def test_play_starts_immediately_when_idle() -> None:
@@ -65,22 +89,12 @@ async def test_skip_requires_votes_from_non_requesters() -> None:
     owner_ctx = make_context(supports_voice=True, voice=voice, user_id="owner")
     await skill.run({"action": "play", "query": "song-a"}, owner_ctx)
 
-    # Distinct voters in the same conversation.
     for i in range(SKIP_THRESHOLD - 1):
-        voter = make_context(
-            supports_voice=True, voice=voice, user_id=f"voter-{i}", conversation_id="conv-1"
-        )
-        owner_ctx_conv = make_context(
-            supports_voice=True, voice=voice, user_id="owner", conversation_id="conv-1"
-        )
-        # ensure same conversation as owner
-        assert owner_ctx_conv.conversation_id == owner_ctx.conversation_id
+        voter = make_context(supports_voice=True, voice=voice, user_id=f"voter-{i}")
         result = await skill.run({"action": "skip"}, voter)
         assert "Skip vote added" in (result.text or "")
 
-    final_voter = make_context(
-        supports_voice=True, voice=voice, user_id="voter-final", conversation_id="conv-1"
-    )
+    final_voter = make_context(supports_voice=True, voice=voice, user_id="voter-final")
     result = await skill.run({"action": "skip"}, final_voter)
     assert "Skipped" in (result.text or "")
 
@@ -98,3 +112,53 @@ async def test_stop_clears_and_disconnects() -> None:
 async def test_play_without_voice_capability_fails() -> None:
     result = await MusicSkill().run({"action": "play", "query": "x"}, make_context())
     assert result.is_error
+
+
+async def test_queue_auto_advances_when_track_finishes() -> None:
+    voice = FakeVoicePort()
+    ctx = make_context(supports_voice=True, voice=voice)
+    skill = MusicSkill()
+    await skill.run({"action": "play", "query": "song-a"}, ctx)
+    await skill.run({"action": "play", "query": "song-b"}, ctx)
+
+    # song-a ends on its own -> song-b should start automatically.
+    await voice.finish_current()
+
+    assert [url for url, _ in voice.played] == ["song-a", "song-b"]
+    queue_view = await skill.run({"action": "queue"}, ctx)
+    assert "song-b" in (queue_view.text or "")
+
+
+async def test_auto_advance_stops_when_queue_empty() -> None:
+    voice = FakeVoicePort()
+    ctx = make_context(supports_voice=True, voice=voice)
+    skill = MusicSkill()
+    await skill.run({"action": "play", "query": "only-song"}, ctx)
+
+    await voice.finish_current()  # nothing queued
+
+    assert not voice.is_playing()
+    queue_view = await skill.run({"action": "queue"}, ctx)
+    assert "empty" in (queue_view.text or "").lower()
+
+
+async def test_stale_finished_callback_is_ignored_after_manual_skip() -> None:
+    voice = FakeVoicePort()
+    ctx = make_context(supports_voice=True, voice=voice, user_id="owner")
+    skill = MusicSkill()
+    await skill.run({"action": "play", "query": "song-a"}, ctx)
+    await skill.run({"action": "play", "query": "song-b"}, ctx)
+
+    # Capture song-a's finished-callback, then skip to song-b manually.
+    stale_callback = voice.pending_callback
+    assert stale_callback is not None
+    await skill.run({"action": "skip"}, ctx)
+    assert voice.played[-1][0] == "song-b"
+
+    # song-a's teardown fires its (now stale) callback late: it must be ignored,
+    # not advance past song-b.
+    await stale_callback()
+
+    assert [url for url, _ in voice.played] == ["song-a", "song-b"]  # no third play
+    queue_view = await skill.run({"action": "queue"}, ctx)
+    assert "song-b" in (queue_view.text or "")


### PR DESCRIPTION
Re-lands the **music queue auto-advance** (issue #8, item 3) onto `master`.

> Context: this change was first merged in #9, but that PR targeted the now-orphaned `claude/adoring-lovelace-YWraH` branch rather than `master` (the revival had already landed on `master` via #7). This PR puts the change in its correct home. Same commit, cleanly cherry-picked onto `master` — no conflicts.

## What changed
- `VoicePort.play` gained an optional `on_finished` callback (`TrackFinishedCallback`).
- The Discord adapter fires it from the player's `after` hook (hopped back onto the event loop via `run_coroutine_threadsafe`) when a track ends on its own, so the queue auto-advances — no explicit `/music skip` needed.
- `MusicSkill` guards against stale callbacks with a per-conversation `play_token`: an explicit `skip`/`stop` bumps the token, so the finished-callback fired by tearing down the old track is recognised as superseded and ignored (no double-advance).
- `docs/architecture.md` updated (the previous "known limitation" note is obsolete).

## Tests (offline, no live gateway)
Driven through a fake `VoicePort` that can simulate a track ending:
- auto-advance to the next queued track on natural finish
- stop cleanly when the queue is empty
- **stale finished-callback after a manual skip is ignored**

## Gates
`ruff` ✅ · `mypy --strict` ✅ · `import-linter` ✅ (core/adapter boundary intact) · `pytest` ✅ 35 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_011bwwEbzhjppXQrMyF3zZW6)_