### PR TITLE
Cleanup follow-ups: Derpibooru URL fix, deferred-path refs, ADR renumber

### DIFF
--- a/docs/adr/0005-serverless-deployment.md
+++ b/docs/adr/0005-serverless-deployment.md
@@ -1,4 +1,4 @@
-# ADR 0004: Serverless deployment — HTTP-Interactions core on AWS Lambda, gateway skills as remote workers
+# ADR 0005: Serverless deployment — HTTP-Interactions core on AWS Lambda, gateway skills as remote workers
 
 - Status: Accepted
 - Date: 2026-06-04

--- a/petbot/core/capabilities/boorus/derpibooru.py
+++ b/petbot/core/capabilities/boorus/derpibooru.py
@@ -144,6 +144,8 @@ class DerpibooruProvider:
         url = img.view_url or img.representations.large
         if not url:
             return None
+        if url.startswith("//"):  # `representations` come back protocol-relative
+            url = f"https:{url}"
         rating = _rating(img.tags)
         return Post(
             post_id=img.id,

--- a/petbot/frontends/interactions/__init__.py
+++ b/petbot/frontends/interactions/__init__.py
@@ -9,7 +9,7 @@ adapter verifies the request signature, maps the interaction onto a neutral
 JSON.
 
 It imports **no** ``discord`` (it emits raw JSON), so it runs on minimal
-serverless runtimes. See ``docs/adr/0004-serverless-deployment.md``.
+serverless runtimes. See ``docs/adr/0005-serverless-deployment.md``.
 """
 
 from __future__ import annotations

--- a/petbot/frontends/interactions/handler.py
+++ b/petbot/frontends/interactions/handler.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 #: Per-skill budget for the *immediate* response. Discord cancels an interaction
 #: not answered within 3 seconds of its POST; we cap a skill below that so a slow
 #: or hung skill yields a clear message instead of a silent Discord timeout. The
-#: real fix for genuinely long work is the deferred follow-up path (tracked: #33).
+#: real fix for genuinely long work is the deferred follow-up path (tracked: #35).
 DEFAULT_SKILL_TIMEOUT_SECONDS = 2.5
 
 

--- a/petbot/frontends/interactions/render.py
+++ b/petbot/frontends/interactions/render.py
@@ -55,7 +55,7 @@ def _truncate_to_single_message(text: str, *, limit: int = DISCORD_MAX_TEXT) -> 
     A single *immediate* interaction response is one message (Discord's model),
     so output spanning multiple chunks cannot be delivered here. Rather than
     silently dropping the overflow, we keep as much as fits alongside an explicit
-    notice. Full multi-message output needs the deferred follow-up path (#33).
+    notice. Full multi-message output needs the deferred follow-up path (#35).
     """
     # Reserve worst-case notice width (omitted <= len(text)) so the result is
     # guaranteed to fit within ``limit``.

--- a/tests/test_booru_parse.py
+++ b/tests/test_booru_parse.py
@@ -160,6 +160,18 @@ def test_derpi_parse() -> None:
     assert post.color == 0x00FF00
 
 
+def test_derpi_absolutizes_protocol_relative_url() -> None:
+    # `representations` come back protocol-relative (`//derpicdn.net/...`); when
+    # `view_url` is absent we must add a scheme so Discord can render the image.
+    body = {
+        "total": 1,
+        "images": [{"id": 7, "representations": {"large": "//derpicdn.net/img/large.png"}}],
+    }
+    post = derpibooru.DerpibooruProvider().parse(body)
+    assert post is not None
+    assert post.image_url == "https://derpicdn.net/img/large.png"
+
+
 def test_parse_none_on_empty_or_blocked() -> None:
     e = e621.E621Provider(user_agent="x")
     assert e.parse(load_fixture("e621_empty")) is None


### PR DESCRIPTION
Follow-ups from the issue-tracker cleanup, addressing the two items flagged in #8's "Needs attention":

## 1. Port the one still-relevant fix from stale draft PR #11
PR #11 ("harden booru parsing") predates the #24 rewrite and now conflicts with `master`. Its e621 null-url fix already landed via #24; the only unported piece was **Derpibooru protocol-relative URL absolutization**. The current engine falls back to `representations.large` when `view_url` is absent (`derpibooru.py`), and those URLs come back protocol-relative (`//derpicdn.net/...`) — which Discord can't render. This adds the `//` → `https:` absolutization plus a regression test.

PR #11 can now be closed as superseded.

## 2. Fix the deferred-response code comments
`handler.py` and `render.py` referenced `#33` (the music-remote-skill issue) for "the deferred follow-up path." That mechanism is owned by **#35**; #33 is only a consumer. Comments now point at #35.

## 3. Resolve the duplicate ADR `0004`
Both `0004-logging.md` (#26) and `0004-serverless-deployment.md` (#34) claimed number 0004. Logging landed first (dated 2026-06-02, merged 2026-06-06) so it keeps `0004`; the serverless ADR is renumbered to **`0005`**, with its header and the one code reference (`interactions/__init__.py`) updated.

## Verification
`pytest` (88 passed, 2 skipped) · `ruff check`/`format` · `mypy` (strict) · `lint-imports` (3 contracts kept) — all green.

https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85)_