### PR TITLE
Config &amp; startup: pydantic-settings + per-frontend validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,11 @@
 #      secrets, and run `python -m petbot`. `.env` is gitignored — never
 #      commit it with real secrets.
 
-# --- Required ---
+# Each frontend validates only the secrets it needs (see petbot/config.py):
+# the gateway requires DISCORD_TOKEN; the Lambda requires DISCORD_PUBLIC_KEY.
+
+# --- Discord gateway frontend (`python -m petbot`; the parked /music worker) ---
+# Required to run the gateway. NOT used by the serverless Lambda.
 DISCORD_TOKEN=op://Private/PetBot/discord_token
 
 # dev | prod. `dev` syncs slash commands instantly to DEV_GUILD_ID;
@@ -23,9 +27,10 @@ ENV=dev
 # Guild (server) ID used for instant slash-command sync in dev.
 DEV_GUILD_ID=000000000000000000
 
-# --- HTTP-Interactions frontend only (AWS Lambda; not used by the gateway run) ---
-# The application's public key (Discord Developer Portal → General Information),
-# used to verify Discord's Ed25519 request signatures.
+# --- HTTP-Interactions frontend (AWS Lambda; the blessed deploy path) ---
+# Required for the Lambda. The application's public key (Discord Developer
+# Portal → General Information), used to verify Discord's Ed25519 request
+# signatures. The Lambda does NOT need DISCORD_TOKEN.
 # DISCORD_PUBLIC_KEY=op://Private/PetBot/discord_public_key
 
 # --- Optional: booru auth (raises rate limits; not required) ---

--- a/petbot/__main__.py
+++ b/petbot/__main__.py
@@ -1,22 +1,30 @@
-"""Entry point: ``python -m petbot``.
+"""Entry point: ``python -m petbot`` — starts the Discord **gateway** frontend.
 
-Loads a plaintext ``.env`` if present (the no-1Password fallback), builds
-:class:`Settings` from the environment, and starts the Discord frontend. With
-1Password, run ``op run --env-file=.env -- python -m petbot`` instead — the env
-is already populated and the ``.env`` load below is a harmless no-op.
+The gateway is PetBot's parked ``/music`` worker; the blessed deploy path is the
+serverless HTTP-Interactions Lambda (see ADR 0005). Configuration is read from
+the process environment and a local ``.env`` if present (pydantic-settings loads
+it), so ``op run --env-file=.env -- python -m petbot`` and a plaintext ``.env``
+both work — and ``op run`` simply pre-populates the environment.
 """
 
 from __future__ import annotations
 
-from dotenv import load_dotenv
+from pydantic import ValidationError
 
-from petbot.config import Settings
+from petbot.config import ConfigError, GatewaySettings
 from petbot.frontends.discord import bootstrap
 
 
 def main() -> None:
-    load_dotenv()
-    settings = Settings.from_env()
+    try:
+        settings = GatewaySettings()
+    except ValidationError as exc:
+        raise ConfigError(
+            "Configuration is incomplete — the gateway needs DISCORD_TOKEN. Copy "
+            ".env.example to .env and fill it in, then launch with "
+            "`op run --env-file=.env -- python -m petbot` (or export the variables "
+            f"yourself).\n\n{exc}"
+        ) from exc
     bootstrap.run(settings)
 
 

--- a/petbot/config.py
+++ b/petbot/config.py
@@ -1,17 +1,27 @@
 """Runtime configuration.
 
-The whole application reads configuration from a process environment through the
-:class:`Settings` value object. It does **not** care how the environment was
-populated — ``op run`` (1Password), a plaintext ``.env``, real exported shell
-variables, or a container orchestrator all work identically. That keeps secret
-management an operational choice with zero code lock-in.
+The whole application reads configuration from the process environment. It does
+**not** care how the environment was populated — ``op run`` (1Password), a
+plaintext ``.env``, real exported shell variables, or a container/Lambda's
+injected env all work identically. That keeps secret management an operational
+choice with zero code lock-in.
+
+Configuration is modelled with :mod:`pydantic_settings`: a shared
+:class:`AppSettings` base holds what *every* frontend needs, and one subclass per
+frontend (:class:`GatewaySettings`, :class:`InteractionsSettings`) declares the
+secrets *that* frontend requires. So each entrypoint validates exactly its own
+inputs and fails fast with a :class:`pydantic.ValidationError` when something is
+missing — the gateway needs ``DISCORD_TOKEN``; the Lambda needs only
+``DISCORD_PUBLIC_KEY`` and never the bot token. ``.env`` loading is built in, so
+there is no separate dotenv call at the entrypoints.
 """
 
 from __future__ import annotations
 
-import os
-from collections.abc import Mapping
-from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 #: Default User-Agent sent to booru APIs (overridable via ``USER_AGENT``). The
 #: legacy spoofed-Firefox UA gets blocked; a descriptive one is now required.
@@ -19,31 +29,53 @@ DEFAULT_USER_AGENT = "PetBot/2.0 (https://github.com/auzbuzzard/petbot)"
 
 
 class ConfigError(RuntimeError):
-    """Raised when required configuration is missing or malformed."""
+    """Raised when required configuration is missing or malformed.
 
-
-@dataclass(frozen=True, slots=True)
-class Settings:
-    """Resolved runtime settings.
-
-    Built once at start-up via :meth:`from_env` and injected downwards; nothing
-    reads ``os.environ`` directly except :meth:`from_env`.
+    The entrypoints use this to translate a :class:`pydantic.ValidationError`
+    into a short, operator-friendly message (e.g. "copy ``.env.example``…").
     """
 
-    discord_token: str
+
+class AppSettings(BaseSettings):
+    """Configuration shared by every frontend.
+
+    Read from the process environment (and a local ``.env`` if present), so it is
+    agnostic to how the env was populated. Frozen, like the rest of the app's
+    config: built once at start-up and injected downward.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        frozen=True,
+    )
+
     env: str = "dev"
-    dev_guild_id: int | None = None
-    #: The application's public key, used by the HTTP-Interactions frontend to
-    #: verify Discord's Ed25519 request signatures. Not needed by the gateway
-    #: frontend, hence optional.
-    discord_public_key: str | None = None
     e621_username: str | None = None
     e621_api_key: str | None = None
     derpibooru_api_key: str | None = None
     user_agent: str = DEFAULT_USER_AGENT
     log_level: str = "INFO"
     #: ``"plain"`` | ``"json"``, or ``None`` to derive from :attr:`env`.
-    log_format: str | None = None
+    log_format: Literal["plain", "json"] | None = None
+
+    @field_validator("e621_username", "e621_api_key", "derpibooru_api_key", mode="before")
+    @classmethod
+    def _blank_to_none(cls, value: object) -> object:
+        # Treat an explicitly-empty env var (``E621_API_KEY=``) as unset, matching
+        # the previous ``env.get(...) or None`` behaviour.
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
+    @field_validator("log_format", mode="before")
+    @classmethod
+    def _normalise_log_format(cls, value: object) -> object:
+        # Accept any case (``Plain``) and treat a blank value as unset.
+        if isinstance(value, str):
+            return value.strip().lower() or None
+        return value
 
     @property
     def is_prod(self) -> bool:
@@ -52,55 +84,38 @@ class Settings:
 
     @property
     def resolved_log_format(self) -> str:
-        """The logging profile to use: explicit ``LOG_FORMAT`` wins, else derived
-        from the environment (``prod`` → structured JSON, otherwise human-readable)."""
+        """The logging profile to use: an explicit ``LOG_FORMAT`` wins, else it is
+        derived from :attr:`env` (``prod`` → structured JSON, otherwise plain)."""
         if self.log_format is not None:
             return self.log_format
         return "json" if self.is_prod else "plain"
 
+
+class GatewaySettings(AppSettings):
+    """Configuration for the Discord **gateway** frontend.
+
+    The gateway is the parked ``/music`` worker (the blessed deploy path is the
+    serverless Lambda; see ADR 0005). It requires ``DISCORD_TOKEN`` for the
+    WebSocket login; the public key is not used on this path.
+    """
+
+    discord_token: str
+    dev_guild_id: int | None = None
+
+    @field_validator("dev_guild_id", mode="before")
     @classmethod
-    def from_env(cls, environ: Mapping[str, str] | None = None) -> Settings:
-        """Build :class:`Settings` from a mapping (defaults to ``os.environ``).
+    def _blank_guild_to_none(cls, value: object) -> object:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
-        Raises :class:`ConfigError` if ``DISCORD_TOKEN`` is absent or if
-        ``DEV_GUILD_ID`` is set but not an integer.
-        """
-        env = os.environ if environ is None else environ
 
-        token = env.get("DISCORD_TOKEN")
-        if not token:
-            raise ConfigError(
-                "DISCORD_TOKEN is not set. Copy .env.example to .env and fill it in, "
-                "then launch with `op run --env-file=.env -- python -m petbot` "
-                "(or export the variables yourself)."
-            )
+class InteractionsSettings(AppSettings):
+    """Configuration for the **HTTP-Interactions** frontend (AWS Lambda).
 
-        raw_guild = env.get("DEV_GUILD_ID")
-        if raw_guild:
-            try:
-                dev_guild_id: int | None = int(raw_guild)
-            except ValueError as exc:
-                raise ConfigError(f"DEV_GUILD_ID must be an integer, got {raw_guild!r}.") from exc
-        else:
-            dev_guild_id = None
+    Requires ``DISCORD_PUBLIC_KEY`` to verify Discord's Ed25519 request
+    signatures. The bot token is never used at request time, so it is **not**
+    required here — the Lambda boots on the public key alone.
+    """
 
-        log_format = env.get("LOG_FORMAT") or None
-        if log_format is not None:
-            log_format = log_format.lower()
-            if log_format not in ("plain", "json"):
-                raise ConfigError(
-                    f"LOG_FORMAT must be 'plain' or 'json', got {env['LOG_FORMAT']!r}."
-                )
-
-        return cls(
-            discord_token=token,
-            env=env.get("ENV", "dev"),
-            dev_guild_id=dev_guild_id,
-            discord_public_key=env.get("DISCORD_PUBLIC_KEY") or None,
-            e621_username=env.get("E621_USERNAME") or None,
-            e621_api_key=env.get("E621_API_KEY") or None,
-            derpibooru_api_key=env.get("DERPIBOORU_API_KEY") or None,
-            user_agent=env.get("USER_AGENT") or DEFAULT_USER_AGENT,
-            log_level=env.get("LOG_LEVEL") or "INFO",
-            log_format=log_format,
-        )
+    discord_public_key: str

--- a/petbot/frontends/discord/bootstrap.py
+++ b/petbot/frontends/discord/bootstrap.py
@@ -14,7 +14,7 @@ import discord
 import httpx
 from discord.ext import commands
 
-from petbot.config import Settings
+from petbot.config import GatewaySettings
 from petbot.core.skills.booru_skill import DerpiSkill, E621Skill
 from petbot.core.skills.context import Capabilities
 from petbot.core.skills.math_skill import MathSkill
@@ -37,7 +37,7 @@ DISCORD_CAPABILITIES = Capabilities(supports_voice=True, supports_rich_embeds=Tr
 class PetBot(commands.Bot):
     """The Discord client. Slash-command first; the prefix is vestigial."""
 
-    def __init__(self, settings: Settings) -> None:
+    def __init__(self, settings: GatewaySettings) -> None:
         intents = discord.Intents.default()
         intents.voice_states = True
         # message_content stays OFF: slash commands don't need it, and it's a
@@ -96,7 +96,7 @@ class PetBot(commands.Bot):
         await super().close()
 
 
-def run(settings: Settings) -> None:
+def run(settings: GatewaySettings) -> None:
     """Start the bot (blocking) with the given settings.
 
     This is the single place logging is configured. ``log_handler=None`` stops

--- a/petbot/frontends/interactions/app.py
+++ b/petbot/frontends/interactions/app.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import httpx
 
-from petbot.config import ConfigError, Settings
+from petbot.config import InteractionsSettings
 from petbot.core.skills.booru_skill import DerpiSkill, E621Skill
 from petbot.core.skills.context import Capabilities
 from petbot.core.skills.math_skill import MathSkill
@@ -33,18 +33,15 @@ INTERACTIONS_CAPABILITIES = Capabilities(
 )
 
 
-def build_handler(settings: Settings, *, http_client: httpx.AsyncClient) -> InteractionHandler:
+def build_handler(
+    settings: InteractionsSettings, *, http_client: httpx.AsyncClient
+) -> InteractionHandler:
     """Wire the stateless skills into an :class:`InteractionHandler`.
 
-    Raises :class:`ConfigError` if ``DISCORD_PUBLIC_KEY`` is unset — it is
-    required to verify Discord's request signatures.
+    ``settings`` guarantees a ``discord_public_key`` (constructing
+    :class:`InteractionsSettings` fails otherwise), so the signature-verification
+    key is always present here.
     """
-    if not settings.discord_public_key:
-        raise ConfigError(
-            "DISCORD_PUBLIC_KEY is not set. The HTTP-Interactions frontend needs the "
-            "application's public key (Discord Developer Portal, General Information) "
-            "to verify request signatures."
-        )
     registry = SkillRegistry(
         [
             MathSkill(),
@@ -72,26 +69,31 @@ def _extract(event: Mapping[str, Any]) -> tuple[bytes, str | None, str | None]:
     return body, headers.get("x-signature-ed25519"), headers.get("x-signature-timestamp")
 
 
-#: Set once per warm container so :func:`configure_logging` (which restarts the
-#: queue listener on each call) runs a single time, not per invocation.
-_logging_configured = False
+#: Process-wide settings, built once per warm container on the first invocation
+#: (not at import, so the module stays importable for tests/tooling). Caching here
+#: keeps env parsing/validation and logging setup off the per-request path; a
+#: misconfigured function fails on its first invocation rather than every call.
+_settings: InteractionsSettings | None = None
 
 
-def _ensure_logging_configured(settings: Settings) -> None:
-    """Configure process logging once per container (never at import time).
+def _startup() -> InteractionsSettings:
+    """Build settings and configure logging once per container; reuse thereafter.
 
-    Mirrors the gateway, which configures logging in ``bootstrap.run``; the
-    Lambda entrypoint is the equivalent start-up point here, so the interactions
-    frontend emits the same structured/plain logs (see ADR 0004) instead of the
-    root logger's unconfigured default.
+    Mirrors the gateway, which configures logging in ``bootstrap.run``; the first
+    Lambda invocation is the equivalent start-up point, so the interactions
+    frontend emits the same structured/plain logs (ADR 0004).
     """
-    global _logging_configured
-    if not _logging_configured:
+    global _settings
+    if _settings is None:
+        settings = InteractionsSettings()
         configure_logging(level=settings.log_level, fmt=settings.resolved_log_format)
-        _logging_configured = True
+        _settings = settings
+    return _settings
 
 
-async def _ahandle(event: Mapping[str, Any], settings: Settings) -> tuple[int, dict[str, Any]]:
+async def _ahandle(
+    event: Mapping[str, Any], settings: InteractionsSettings
+) -> tuple[int, dict[str, Any]]:
     # A short-lived client per invocation keeps it bound to this event loop. A
     # warm-reuse optimization can come later if traffic warrants it.
     async with httpx.AsyncClient(timeout=20.0) as client:
@@ -102,8 +104,7 @@ async def _ahandle(event: Mapping[str, Any], settings: Settings) -> tuple[int, d
 
 def lambda_handler(event: Mapping[str, Any], context: Any = None) -> dict[str, Any]:
     """AWS Lambda Function URL handler: parse the event, run, return a response."""
-    settings = Settings.from_env()
-    _ensure_logging_configured(settings)
+    settings = _startup()
     status, payload = asyncio.run(_ahandle(event, settings))
     return {
         "statusCode": status,

--- a/petbot/logging_setup.py
+++ b/petbot/logging_setup.py
@@ -14,7 +14,8 @@ The configuration itself lives in JSON (loaded via :mod:`importlib.resources` an
   blocks the asyncio event loop (the prod default).
 
 Nothing here reads the environment: the level and profile are passed in by the
-caller, which got them from :class:`~petbot.config.Settings` (the one env reader).
+caller, which got them from the :class:`~petbot.config.AppSettings` config (the
+only place that reads the environment).
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,19 @@ dependencies = [
     "aiohttp>=3.9",
     "httpx>=0.27",
     "pydantic>=2",
+    "pydantic-settings>=2",
     "yt-dlp>=2024.0.0",
     "numexpr>=2.8",
     "numpy>=1.26",
     "certifi>=2024.0.0",
+    # Used by pydantic-settings to read the optional local `.env` file.
     "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]
 # The HTTP-Interactions frontend (AWS Lambda). PyNaCl verifies Discord's Ed25519
 # request signatures. Kept out of the base install so the gateway runtime stays
-# lean. See docs/adr/0004-serverless-deployment.md.
+# lean. See docs/adr/0005-serverless-deployment.md.
 interactions = [
     "pynacl>=1.5",
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+"""Tests for the pydantic-settings config: per-frontend requirements and parsing.
+
+Constructed with ``_env_file=None`` so a developer's real ``.env`` never leaks
+into the assertions; required values are passed as explicit kwargs (which outrank
+env), and ``monkeypatch`` clears anything a stray shell export might supply.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from petbot.config import AppSettings, GatewaySettings, InteractionsSettings
+
+# --- per-frontend requirements -----------------------------------------------
+
+
+def test_gateway_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    with pytest.raises(ValidationError):
+        GatewaySettings(_env_file=None)
+
+
+def test_gateway_accepts_token_and_parses_guild() -> None:
+    settings = GatewaySettings(_env_file=None, discord_token="t", dev_guild_id="123")
+    assert settings.discord_token == "t"
+    assert settings.dev_guild_id == 123
+
+
+def test_gateway_blank_guild_is_none() -> None:
+    settings = GatewaySettings(_env_file=None, discord_token="t", dev_guild_id="")
+    assert settings.dev_guild_id is None
+
+
+def test_gateway_rejects_non_integer_guild() -> None:
+    with pytest.raises(ValidationError):
+        GatewaySettings(_env_file=None, discord_token="t", dev_guild_id="abc")
+
+
+def test_interactions_boots_without_a_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The #38 guarantee: the Lambda needs only the public key, never the bot token.
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    settings = InteractionsSettings(_env_file=None, discord_public_key="ab12")
+    assert settings.discord_public_key == "ab12"
+
+
+def test_interactions_requires_public_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISCORD_PUBLIC_KEY", raising=False)
+    with pytest.raises(ValidationError):
+        InteractionsSettings(_env_file=None)
+
+
+# --- shared parsing ----------------------------------------------------------
+
+
+def test_booru_creds_default_to_none() -> None:
+    settings = AppSettings(_env_file=None)
+    assert settings.e621_username is None
+    assert settings.derpibooru_api_key is None
+
+
+def test_blank_optional_is_none() -> None:
+    settings = AppSettings(_env_file=None, e621_api_key="")
+    assert settings.e621_api_key is None
+
+
+def test_log_defaults() -> None:
+    settings = AppSettings(_env_file=None)
+    assert settings.log_level == "INFO"
+    assert settings.log_format is None
+    assert settings.resolved_log_format == "plain"
+
+
+def test_prod_defaults_to_json() -> None:
+    settings = AppSettings(_env_file=None, env="prod")
+    assert settings.is_prod is True
+    assert settings.resolved_log_format == "json"
+
+
+def test_explicit_log_format_wins_and_is_normalised() -> None:
+    settings = AppSettings(_env_file=None, env="prod", log_format="Plain")
+    assert settings.log_format == "plain"  # case-normalised; explicit wins over env
+    assert settings.resolved_log_format == "plain"
+
+
+def test_rejects_bad_log_format() -> None:
+    with pytest.raises(ValidationError):
+        AppSettings(_env_file=None, log_format="yaml")

--- a/tests/test_interactions_adapter.py
+++ b/tests/test_interactions_adapter.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 from nacl.signing import SigningKey
 
-from petbot.config import ConfigError, Settings
+from petbot.config import InteractionsSettings
 from petbot.core.skills.base import Skill
 from petbot.core.skills.context import Capabilities, EmbedSpec, SkillContext, SkillResult
 from petbot.core.skills.math_skill import MathSkill
@@ -279,16 +279,19 @@ async def test_unexpected_skill_exception_is_caught() -> None:
 # --- app (composition root + Lambda entrypoint) ------------------------------
 
 
-async def test_build_handler_requires_public_key() -> None:
+async def test_build_handler_builds_from_settings() -> None:
+    settings = InteractionsSettings(_env_file=None, discord_public_key="ab12")
     async with httpx.AsyncClient() as client:
-        with pytest.raises(ConfigError, match="DISCORD_PUBLIC_KEY"):
-            app.build_handler(Settings(discord_token="x"), http_client=client)
+        handler = app.build_handler(settings, http_client=client)
+    assert isinstance(handler, InteractionHandler)
 
 
 def test_lambda_handler_answers_ping(monkeypatch: pytest.MonkeyPatch) -> None:
     signing_key, public_key = _keypair()
-    monkeypatch.setenv("DISCORD_TOKEN", "x")
+    # The Lambda needs only the public key — no bot token on this path.
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
     monkeypatch.setenv("DISCORD_PUBLIC_KEY", public_key)
+    monkeypatch.setattr(app, "_settings", None)  # rebuild the cached cold-start settings
     body = '{"type":1}'
     event = {
         "headers": {

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,8 +1,9 @@
-"""Tests for the logging setup: JSON formatter, the non-error filter, the
-``configure_logging`` entrypoint, and ``Settings`` log parsing.
+"""Tests for the logging setup: JSON formatter, the non-error filter, and the
+``configure_logging`` entrypoint.
 
 These never touch the network and restore the root logger afterwards, so they
-don't leak handlers into the rest of the suite.
+don't leak handlers into the rest of the suite. (``Settings`` log-field parsing
+is covered in ``test_config.py``.)
 """
 
 from __future__ import annotations
@@ -15,7 +16,6 @@ from types import TracebackType
 
 import pytest
 
-from petbot.config import ConfigError, Settings
 from petbot.logging_setup import JSONFormatter, NonErrorFilter, configure_logging
 
 
@@ -126,32 +126,3 @@ def test_configure_logging_rejects_unknown_format(restore_logging: None) -> None
 def test_configure_logging_rejects_unknown_level(restore_logging: None) -> None:
     with pytest.raises(ValueError, match="Unknown log level"):
         configure_logging(level="LOUD", fmt="plain")
-
-
-# --- Settings log parsing ----------------------------------------------------
-
-
-def test_settings_log_defaults() -> None:
-    settings = Settings.from_env({"DISCORD_TOKEN": "x"})
-    assert settings.log_level == "INFO"
-    assert settings.log_format is None
-    assert settings.resolved_log_format == "plain"
-
-
-def test_settings_prod_defaults_to_json() -> None:
-    settings = Settings.from_env({"DISCORD_TOKEN": "x", "ENV": "prod"})
-    assert settings.resolved_log_format == "json"
-
-
-def test_settings_log_overrides_are_parsed() -> None:
-    settings = Settings.from_env(
-        {"DISCORD_TOKEN": "x", "ENV": "prod", "LOG_LEVEL": "DEBUG", "LOG_FORMAT": "Plain"}
-    )
-    assert settings.log_level == "DEBUG"
-    assert settings.log_format == "plain"  # explicit LOG_FORMAT wins over the env default
-    assert settings.resolved_log_format == "plain"
-
-
-def test_settings_rejects_bad_log_format() -> None:
-    with pytest.raises(ConfigError, match="LOG_FORMAT"):
-        Settings.from_env({"DISCORD_TOKEN": "x", "LOG_FORMAT": "yaml"})


### PR DESCRIPTION
## What & why

Reworks env-var injection and app startup onto **pydantic-settings**, the idiomatic 12-factor pattern, and makes config **per-frontend** so each entrypoint validates exactly the secrets it needs. Absorbs and closes #38 (the `DISCORD_TOKEN` decoupling) as one coherent change. Part of the serverless deployment epic #28.

Config stays **agnostic to how the environment is populated** — `op run`, a plaintext `.env`, exported shell vars, or a Lambda/container's injected env all work identically.

## Changes

- **`petbot/config.py`** — replaces the hand-rolled `Settings.from_env` dataclass with:
  - `AppSettings(BaseSettings)` — shared fields (booru creds, user-agent, env, logging), native `.env` support, frozen.
  - `GatewaySettings` — requires `DISCORD_TOKEN`, parses `DEV_GUILD_ID: int | None`.
  - `InteractionsSettings` — requires **only** `DISCORD_PUBLIC_KEY`; the Lambda never needs the bot token (**closes #38**).
  - Validators replace manual parsing (`int()`, `LOG_FORMAT` membership/case, `or None`).
- **`petbot/frontends/interactions/app.py`** — settings + logging now built **once per warm container** via a cached `_startup()` (off the per-request path); drops the `_logging_configured` global and the ad-hoc public-key check in `build_handler` (now enforced by `InteractionsSettings` construction).
- **`petbot/__main__.py`** — `GatewaySettings()`; drops the explicit `load_dotenv` (pydantic-settings reads `.env`); translates `ValidationError` → friendly `ConfigError`.
- **`bootstrap.py` / `logging_setup.py`** — type hints + docstrings updated for the new classes.
- **`pyproject.toml`** — add `pydantic-settings>=2`; keep `python-dotenv` (now used *by* pydantic-settings); fix a stale `0004`→`0005` ADR reference.
- **`.env.example`** — documents which vars each frontend requires.

## Notes for review

- **Cold-start init is lazy/cached, not at import time.** A module-level `InteractionsSettings()` would break imports/tests; `_startup()` builds on the first invocation instead. So a misconfigured Lambda fails on its **first request**, not at deploy-init — acceptable, and the #14 smoke test catches it. Flagging in case you'd prefer init-phase failure.
- **`python-dotenv` kept** because pydantic-settings needs it for `env_file` support.

## Tests & gates

- New `tests/test_config.py` covers per-frontend requirements (gateway needs token; interactions boots without one) and shared parsing (guild int, blank→None, log-format normalisation/rejection).
- Adapter + logging tests updated for the new settings classes.
- All green: `pytest` 96 passed / 2 skipped, `ruff check`/`format`, `mypy --strict` (pydantic plugin), `lint-imports` 3/3 contracts kept.

Closes #38.

https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85)_