### PR TITLE
Terraform: interactions Lambda + Function URL + IAM (#30)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.9.8"
+          terraform_version: "1.13.1"
 
       - name: Format check
         run: terraform -chdir=deploy/terraform fmt -check -recursive

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,40 @@
+name: Terraform
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "deploy/terraform/**"
+      - ".github/workflows/terraform.yml"
+  pull_request:
+    paths:
+      - "deploy/terraform/**"
+      - ".github/workflows/terraform.yml"
+
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.8"
+
+      - name: Format check
+        run: terraform -chdir=deploy/terraform fmt -check -recursive
+
+      # `-backend=false` so validation needs no AWS credentials or remote state.
+      - name: Validate (root stack)
+        run: |
+          terraform -chdir=deploy/terraform init -backend=false
+          terraform -chdir=deploy/terraform validate
+
+      - name: Validate (bootstrap stack)
+        run: |
+          terraform -chdir=deploy/terraform/bootstrap init -backend=false
+          terraform -chdir=deploy/terraform/bootstrap validate

--- a/deploy/Dockerfile.lambda
+++ b/deploy/Dockerfile.lambda
@@ -9,7 +9,10 @@
 #
 #   docker build --platform linux/arm64 -f deploy/Dockerfile.lambda -t <ecr_url>:<tag> .
 #
-FROM public.ecr.aws/lambda/python:3.13
+# Match the runtime to what CI tests and the toolchain targets (pyproject:
+# requires-python, mypy, ruff are all 3.12). Shipping a newer interpreter than
+# CI exercises would deploy an untested runtime — keep them in lockstep.
+FROM public.ecr.aws/lambda/python:3.12
 
 # ${LAMBDA_TASK_ROOT} is /var/task, already the WORKDIR and on sys.path.
 COPY pyproject.toml README.md ./

--- a/deploy/Dockerfile.lambda
+++ b/deploy/Dockerfile.lambda
@@ -9,7 +9,7 @@
 #
 #   docker build --platform linux/arm64 -f deploy/Dockerfile.lambda -t <ecr_url>:<tag> .
 #
-FROM public.ecr.aws/lambda/python:3.12
+FROM public.ecr.aws/lambda/python:3.13
 
 # ${LAMBDA_TASK_ROOT} is /var/task, already the WORKDIR and on sys.path.
 COPY pyproject.toml README.md ./

--- a/deploy/Dockerfile.lambda
+++ b/deploy/Dockerfile.lambda
@@ -1,0 +1,24 @@
+# PetBot HTTP-Interactions Lambda image.
+#
+# A container image (not a zip) because the adapter pulls in C-extensions
+# (pynacl for Ed25519, numexpr/numpy for /math); the AWS Lambda Python base
+# image gives a matching manylinux runtime with no wheel wrangling.
+#
+# Build from the repository root (the build context must see pyproject.toml and
+# petbot/), targeting arm64 to match the Lambda's Graviton architecture:
+#
+#   docker build --platform linux/arm64 -f deploy/Dockerfile.lambda -t <ecr_url>:<tag> .
+#
+FROM public.ecr.aws/lambda/python:3.12
+
+# ${LAMBDA_TASK_ROOT} is /var/task, already the WORKDIR and on sys.path.
+COPY pyproject.toml README.md ./
+COPY petbot ./petbot
+
+# `[interactions]` pulls in pynacl; the base dependencies bring pydantic,
+# pydantic-settings, httpx, numexpr, etc. No secrets are baked in — they are
+# supplied as environment variables by Terraform (see deploy/terraform).
+RUN pip install --no-cache-dir ".[interactions]"
+
+# module.function the Lambda runtime invokes per request.
+CMD ["petbot.frontends.interactions.app.lambda_handler"]

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,13 @@
+# Terraform working files — never commit state, provider binaries, or secrets.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+.terraform.tfstate.lock.info
+
+# Real inputs (the *.example templates are committed; the filled-in copies aren't).
+backend.hcl
+*.tfvars
+!*.tfvars.example

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,85 @@
+# PetBot interactions Lambda — Terraform
+
+Infrastructure-as-code for the serverless HTTP-Interactions frontend (epic #28,
+issue #30): an AWS Lambda **container image** behind a **Function URL**, with a
+least-privilege IAM role. The Function URL output is what #31 sets as Discord's
+Interactions Endpoint URL.
+
+```
+bootstrap/        one-time S3 state bucket + DynamoDB lock table (local state)
+*.tf              the Lambda + ECR + IAM + Function URL stack (S3 remote state)
+backend.hcl.example       remote-state backend config (copy -> backend.hcl)
+terraform.tfvars.example  inputs (copy -> terraform.tfvars); no secrets here
+```
+
+The Lambda image is built from [`../Dockerfile.lambda`](../Dockerfile.lambda).
+
+## Prerequisites
+
+- An AWS account with credentials in your shell (e.g. `aws sso login`).
+- Terraform >= 1.6, Docker, and the AWS CLI.
+- Secrets live in **SSM SecureString** parameters, created out-of-band so their
+  values never touch Terraform state as managed resources:
+
+  ```sh
+  aws ssm put-parameter --type SecureString \
+    --name /petbot/interactions/discord_public_key --value "<application public key>"
+  # optional booru auth:
+  # aws ssm put-parameter --type SecureString --name /petbot/interactions/derpibooru_api_key --value "..."
+  ```
+
+  > Note: the values are injected into the Lambda's environment at apply time, so
+  > they do land in Terraform **state**. The state bucket is encrypted, versioned,
+  > and private to contain this; fetching SSM at runtime (state stays secret-free)
+  > is a documented future hardening (#17).
+
+## One-time: bootstrap remote state
+
+```sh
+cd bootstrap
+terraform init
+terraform apply -var "state_bucket=petbot-tfstate-<your-account-id>"
+cd ..
+cp backend.hcl.example backend.hcl   # fill in the bucket name
+```
+
+## Deploy
+
+Because the function is pinned to the image digest, the image must exist before
+the main apply — so it's a two-step the first time:
+
+```sh
+cp terraform.tfvars.example terraform.tfvars   # adjust region, SSM names, etc.
+terraform init -backend-config=backend.hcl
+
+# 1. Create just the ECR repo.
+terraform apply -target=aws_ecr_repository.this
+
+# 2. Build + push the arm64 image to that repo.
+REPO=$(terraform output -raw ecr_repository_url)
+aws ecr get-login-password | docker login --username AWS --password-stdin "${REPO%/*}"
+docker build --platform linux/arm64 -f ../Dockerfile.lambda -t "$REPO:latest" ../..
+docker push "$REPO:latest"
+
+# 3. Stand up the function + Function URL.
+terraform apply
+
+terraform output function_url   # -> set this as Discord's Interactions Endpoint URL (#31)
+```
+
+For subsequent deploys, push a new image (prefer a unique tag, e.g. the git SHA,
+set via `-var image_tag=...`) and re-run `terraform apply`.
+
+## Teardown
+
+```sh
+terraform destroy
+# and, if you want to remove state storage too:
+cd bootstrap && terraform destroy -var "state_bucket=petbot-tfstate-<your-account-id>"
+```
+
+## CI
+
+`.github/workflows/terraform.yml` runs `fmt -check` + `validate` on PRs (no AWS
+credentials needed). `plan`/`apply` are run manually from here for now; a full
+OIDC pipeline can be added later.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -70,6 +70,21 @@ terraform output function_url   # -> set this as Discord's Interactions Endpoint
 For subsequent deploys, push a new image (prefer a unique tag, e.g. the git SHA,
 set via `-var image_tag=...`) and re-run `terraform apply`.
 
+## Cost & retention
+
+The stack keeps storage bounded and `destroy` complete:
+
+- **ECR lifecycle** (`retention.tf`) expires untagged images after
+  `ecr_untagged_expire_days` and keeps only the last `ecr_keep_last_images`.
+- **CloudWatch Logs** are an explicit `aws_cloudwatch_log_group` with
+  `log_retention_days` retention — so logs don't accumulate forever, and
+  `terraform destroy` removes the group (Lambda's auto-created one never expires
+  and wouldn't be owned by Terraform).
+- **Cost alerts** are opt-in: AWS has no hard spend cap, so set
+  `monthly_budget_usd` + `budget_alert_emails` to create an AWS Budget that
+  emails you at 80% and 100% of the limit. At PetBot's scale spend is ~$0, so
+  this is a smoke alarm, not a throttle.
+
 ## Teardown
 
 ```sh

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -6,7 +6,7 @@ least-privilege IAM role. The Function URL output is what #31 sets as Discord's
 Interactions Endpoint URL.
 
 ```
-bootstrap/        one-time S3 state bucket + DynamoDB lock table (local state)
+bootstrap/        one-time encrypted S3 state bucket (local state)
 *.tf              the Lambda + ECR + IAM + Function URL stack (S3 remote state)
 backend.hcl.example       remote-state backend config (copy -> backend.hcl)
 terraform.tfvars.example  inputs (copy -> terraform.tfvars); no secrets here
@@ -17,7 +17,7 @@ The Lambda image is built from [`../Dockerfile.lambda`](../Dockerfile.lambda).
 ## Prerequisites
 
 - An AWS account with credentials in your shell (e.g. `aws sso login`).
-- Terraform >= 1.6, Docker, and the AWS CLI.
+- Terraform >= 1.11 (for S3-native state locking), Docker, and the AWS CLI.
 - Secrets live in **SSM SecureString** parameters, created out-of-band so their
   values never touch Terraform state as managed resources:
 

--- a/deploy/terraform/backend.hcl.example
+++ b/deploy/terraform/backend.hcl.example
@@ -1,0 +1,8 @@
+# Copy to backend.hcl and fill in, then:
+#   terraform init -backend-config=backend.hcl
+# The bucket and lock table are created by deploy/terraform/bootstrap.
+bucket         = "petbot-tfstate-<your-account-id>"
+key            = "interactions/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "petbot-tf-locks"
+encrypt        = true

--- a/deploy/terraform/backend.hcl.example
+++ b/deploy/terraform/backend.hcl.example
@@ -1,8 +1,9 @@
 # Copy to backend.hcl and fill in, then:
 #   terraform init -backend-config=backend.hcl
-# The bucket and lock table are created by deploy/terraform/bootstrap.
-bucket         = "petbot-tfstate-<your-account-id>"
-key            = "interactions/terraform.tfstate"
-region         = "us-east-1"
-dynamodb_table = "petbot-tf-locks"
-encrypt        = true
+# The bucket is created by deploy/terraform/bootstrap. State locking is native
+# to S3 via use_lockfile (Terraform >= 1.11) — no DynamoDB table required.
+bucket       = "petbot-tfstate-<your-account-id>"
+key          = "interactions/terraform.tfstate"
+region       = "us-east-1"
+encrypt      = true
+use_lockfile = true

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -1,5 +1,6 @@
 # One-time bootstrap for the remote state backend: an encrypted, versioned S3
-# bucket for state and a DynamoDB table for locking. Uses LOCAL state itself
+# bucket for state. State locking is handled natively by S3 (`use_lockfile`,
+# Terraform >= 1.11), so no DynamoDB table is needed. Uses LOCAL state itself
 # (chicken-and-egg), so just keep the small state file it produces.
 #
 #   cd deploy/terraform/bootstrap
@@ -7,12 +8,12 @@
 #   terraform apply -var "state_bucket=petbot-tfstate-<your-account-id>"
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }
@@ -29,11 +30,6 @@ variable "aws_region" {
 variable "state_bucket" {
   type        = string
   description = "Globally-unique S3 bucket name for Terraform state."
-}
-
-variable "lock_table" {
-  type    = string
-  default = "petbot-tf-locks"
 }
 
 resource "aws_s3_bucket" "state" {
@@ -67,21 +63,6 @@ resource "aws_s3_bucket_public_access_block" "state" {
   restrict_public_buckets = true
 }
 
-resource "aws_dynamodb_table" "locks" {
-  name         = var.lock_table
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "LockID"
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-}
-
 output "state_bucket" {
   value = aws_s3_bucket.state.id
-}
-
-output "lock_table" {
-  value = aws_dynamodb_table.locks.name
 }

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -1,0 +1,87 @@
+# One-time bootstrap for the remote state backend: an encrypted, versioned S3
+# bucket for state and a DynamoDB table for locking. Uses LOCAL state itself
+# (chicken-and-egg), so just keep the small state file it produces.
+#
+#   cd deploy/terraform/bootstrap
+#   terraform init
+#   terraform apply -var "state_bucket=petbot-tfstate-<your-account-id>"
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "state_bucket" {
+  type        = string
+  description = "Globally-unique S3 bucket name for Terraform state."
+}
+
+variable "lock_table" {
+  type    = string
+  default = "petbot-tf-locks"
+}
+
+resource "aws_s3_bucket" "state" {
+  bucket = var.state_bucket
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "locks" {
+  name         = var.lock_table
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+output "state_bucket" {
+  value = aws_s3_bucket.state.id
+}
+
+output "lock_table" {
+  value = aws_dynamodb_table.locks.name
+}

--- a/deploy/terraform/budget.tf
+++ b/deploy/terraform/budget.tf
@@ -1,0 +1,24 @@
+# Optional monthly cost guardrail. AWS has no hard "stop spending" switch, so
+# this is an *alert* (AWS Budgets), not a cap. Enable it by setting
+# monthly_budget_usd > 0 and at least one alert email; it then notifies at 80%
+# and 100% of the limit. Disabled by default (count = 0).
+resource "aws_budgets_budget" "monthly" {
+  count = var.monthly_budget_usd > 0 && length(var.budget_alert_emails) > 0 ? 1 : 0
+
+  name         = "${var.name_prefix}-monthly"
+  budget_type  = "COST"
+  time_unit    = "MONTHLY"
+  limit_amount = tostring(var.monthly_budget_usd)
+  limit_unit   = "USD"
+
+  dynamic "notification" {
+    for_each = toset([80, 100])
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = notification.value
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = var.budget_alert_emails
+    }
+  }
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 # --- Container image registry -------------------------------------------------
 
 resource "aws_ecr_repository" "this" {
@@ -60,6 +58,10 @@ resource "aws_lambda_function" "this" {
   environment {
     variables = local.lambda_env
   }
+
+  # Ensure our retention-managed log group exists before the function can be
+  # invoked, so Lambda doesn't auto-create an unmanaged, never-expiring one.
+  depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
 resource "aws_lambda_function_url" "this" {

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,78 @@
+data "aws_caller_identity" "current" {}
+
+# --- Container image registry -------------------------------------------------
+
+resource "aws_ecr_repository" "this" {
+  name                 = var.name_prefix
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# Resolve the tag to an immutable digest so re-pushing the same tag and
+# re-applying actually updates the function. Requires the image to exist before
+# the main apply (see the two-step bootstrap in README).
+data "aws_ecr_image" "this" {
+  repository_name = aws_ecr_repository.this.name
+  image_tag       = var.image_tag
+}
+
+# --- Execution role -----------------------------------------------------------
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = "${var.name_prefix}-role"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+# CloudWatch Logs only — secrets are injected as env at deploy, so the function
+# needs no runtime SSM/KMS access. (A future runtime-fetch model would add a
+# scoped ssm:GetParameter policy here.)
+resource "aws_iam_role_policy_attachment" "logs" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# --- Function + public URL ----------------------------------------------------
+
+resource "aws_lambda_function" "this" {
+  function_name = var.name_prefix
+  role          = aws_iam_role.lambda.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.this.repository_url}@${data.aws_ecr_image.this.image_digest}"
+  architectures = ["arm64"]
+  memory_size   = var.memory_size
+  timeout       = var.timeout
+
+  environment {
+    variables = local.lambda_env
+  }
+}
+
+resource "aws_lambda_function_url" "this" {
+  function_name      = aws_lambda_function.this.function_name
+  authorization_type = "NONE"
+}
+
+# AUTH_NONE still requires an explicit public-invoke permission; the security
+# boundary is the Ed25519 signature the handler verifies, not IAM.
+resource "aws_lambda_permission" "function_url" {
+  statement_id           = "FunctionURLAllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.this.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}

--- a/deploy/terraform/music.tf
+++ b/deploy/terraform/music.tf
@@ -1,0 +1,46 @@
+# Future blocks, intentionally commented so they don't provision anything yet.
+# Uncomment when the corresponding issue lands; both reuse the role/function
+# defined in main.tf.
+
+# --- Deferred-response self-invoke (#35) --------------------------------------
+# The deferred-response path returns a type-5 ACK and then self-invokes the same
+# function asynchronously to finish the work. That needs a scoped permission to
+# invoke itself:
+#
+# resource "aws_iam_role_policy" "self_invoke" {
+#   name = "${var.name_prefix}-self-invoke"
+#   role = aws_iam_role.lambda.id
+#
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [{
+#       Effect   = "Allow"
+#       Action   = "lambda:InvokeFunction"
+#       Resource = aws_lambda_function.this.arn
+#     }]
+#   })
+# }
+
+# --- Music remote-skill bus (#33) ---------------------------------------------
+# Music runs as a cluster worker fed by an SQS queue; the Lambda enqueues jobs,
+# the worker pulls them (no inbound to home). Activated by #33.
+#
+# resource "aws_sqs_queue" "music_jobs" {
+#   name                       = "${var.name_prefix}-music-jobs"
+#   message_retention_seconds  = 3600
+#   visibility_timeout_seconds = 300
+# }
+#
+# resource "aws_iam_role_policy" "music_enqueue" {
+#   name = "${var.name_prefix}-music-enqueue"
+#   role = aws_iam_role.lambda.id
+#
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [{
+#       Effect   = "Allow"
+#       Action   = "sqs:SendMessage"
+#       Resource = aws_sqs_queue.music_jobs.arn
+#     }]
+#   })
+# }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "function_url" {
+  description = "Public HTTPS endpoint. Paste into Discord's Interactions Endpoint URL (#31)."
+  value       = aws_lambda_function_url.this.function_url
+}
+
+output "ecr_repository_url" {
+  description = "Push the Lambda image here before the main apply."
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "lambda_function_name" {
+  description = "Name of the deployed interactions function."
+  value       = aws_lambda_function.this.function_name
+}

--- a/deploy/terraform/providers.tf
+++ b/deploy/terraform/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = "petbot"
+      Component = "interactions-lambda"
+      ManagedBy = "terraform"
+    }
+  }
+}

--- a/deploy/terraform/retention.tf
+++ b/deploy/terraform/retention.tf
@@ -1,0 +1,40 @@
+# Data-growth controls. Without these, pushed images and logs accumulate
+# forever. Managing the log group here also means `terraform destroy` removes it
+# (otherwise Lambda auto-creates a never-expiring group that TF wouldn't own).
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = var.ecr_untagged_expire_days
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep only the most recent tagged images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.ecr_keep_last_images
+        }
+        action = { type = "expire" }
+      },
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  # Lambda writes to /aws/lambda/<function-name>; creating it explicitly lets us
+  # set retention (and own its lifecycle) instead of the never-expire default.
+  name              = "/aws/lambda/${var.name_prefix}"
+  retention_in_days = var.log_retention_days
+}

--- a/deploy/terraform/secrets.tf
+++ b/deploy/terraform/secrets.tf
@@ -1,0 +1,37 @@
+# Runtime secrets are stored as SSM SecureString parameters created out-of-band
+# (see README) and read here to populate the Lambda's environment. The bot only
+# ever reads os.environ, so the app stays platform-agnostic.
+#
+# Trade-off (flagged for review): injecting via the Lambda environment means the
+# decrypted values land in the Lambda's config and therefore in Terraform state.
+# The S3 backend is encrypted, versioned, and access-controlled to contain this.
+# Keeping state fully secret-free would require the function to fetch SSM at
+# runtime instead — a documented future hardening (tracked with secrets/ops #17).
+
+data "aws_ssm_parameter" "public_key" {
+  name            = var.public_key_ssm_parameter
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "booru" {
+  for_each        = var.booru_ssm_parameters
+  name            = each.value
+  with_decryption = true
+}
+
+locals {
+  base_env = merge(
+    {
+      ENV       = var.lambda_environment
+      LOG_LEVEL = var.log_level
+    },
+    var.user_agent != "" ? { USER_AGENT = var.user_agent } : {},
+  )
+
+  secret_env = merge(
+    { DISCORD_PUBLIC_KEY = data.aws_ssm_parameter.public_key.value },
+    { for env_name, param in data.aws_ssm_parameter.booru : env_name => param.value },
+  )
+
+  lambda_env = merge(local.base_env, local.secret_env)
+}

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,19 @@
+# Copy to terraform.tfvars and adjust. No secrets live here — secret *values*
+# are stored as SSM SecureString parameters (see README), referenced by name.
+
+aws_region = "us-east-1"
+image_tag  = "latest" # prefer a unique tag per deploy, e.g. the git SHA
+
+# ENV drives the logging profile (prod => structured JSON).
+lambda_environment = "prod"
+log_level          = "INFO"
+
+# Required SSM SecureString holding the Discord application public key.
+public_key_ssm_parameter = "/petbot/interactions/discord_public_key"
+
+# Optional booru auth: ENV-VAR-NAME => SSM-parameter-name.
+# booru_ssm_parameters = {
+#   DERPIBOORU_API_KEY = "/petbot/interactions/derpibooru_api_key"
+#   E621_USERNAME      = "/petbot/interactions/e621_username"
+#   E621_API_KEY       = "/petbot/interactions/e621_api_key"
+# }

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,6 +1,8 @@
 # Copy to terraform.tfvars and adjust. No secrets live here — secret *values*
 # are stored as SSM SecureString parameters (see README), referenced by name.
 
+# us-east-1 is AWS's cheapest US region and where ACM/CloudFront (future custom
+# domain) must live. us-east-2 / us-west-2 cost the same; pick one if you prefer.
 aws_region = "us-east-1"
 image_tag  = "latest" # prefer a unique tag per deploy, e.g. the git SHA
 
@@ -17,3 +19,12 @@ public_key_ssm_parameter = "/petbot/interactions/discord_public_key"
 #   E621_USERNAME      = "/petbot/interactions/e621_username"
 #   E621_API_KEY       = "/petbot/interactions/e621_api_key"
 # }
+
+# --- Retention / cost (sensible defaults; override to taste) ---
+# log_retention_days       = 30
+# ecr_keep_last_images     = 10
+# ecr_untagged_expire_days = 7
+
+# Optional monthly cost alert (AWS Budgets). Both must be set to enable it.
+# monthly_budget_usd  = 5
+# budget_alert_emails = ["you@example.com"]

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,71 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for all resources."
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Name applied to the Lambda, ECR repo, and IAM role."
+  default     = "petbot-interactions"
+}
+
+variable "image_tag" {
+  type        = string
+  description = <<-EOT
+    ECR image tag to deploy. The image must be built and pushed before the main
+    apply (the function is pinned to the tag's digest); use a unique tag per
+    deploy (e.g. the git SHA) so a re-push is picked up. See README.
+  EOT
+  default     = "latest"
+}
+
+variable "lambda_environment" {
+  type        = string
+  description = "Value of the bot's ENV variable (drives logging profile)."
+  default     = "prod"
+}
+
+variable "log_level" {
+  type        = string
+  description = "Root log level: DEBUG | INFO | WARNING | ERROR | CRITICAL."
+  default     = "INFO"
+}
+
+variable "user_agent" {
+  type        = string
+  description = "Optional override for the booru User-Agent; empty uses the app default."
+  default     = ""
+}
+
+variable "memory_size" {
+  type        = number
+  description = "Lambda memory (MB); also scales CPU, which helps cold starts and numpy."
+  default     = 1024
+}
+
+variable "timeout" {
+  type        = number
+  description = "Lambda timeout (seconds). The handler caps skills well under Discord's 3s."
+  default     = 10
+}
+
+variable "public_key_ssm_parameter" {
+  type        = string
+  description = <<-EOT
+    Name of the SSM SecureString parameter holding DISCORD_PUBLIC_KEY. Created
+    out-of-band (see README) so its value is never committed; Terraform reads it
+    to populate the Lambda's environment.
+  EOT
+  default     = "/petbot/interactions/discord_public_key"
+}
+
+variable "booru_ssm_parameters" {
+  type        = map(string)
+  description = <<-EOT
+    Optional booru auth, as a map of ENV-VAR-NAME => SSM-parameter-name, e.g.
+    { DERPIBOORU_API_KEY = "/petbot/interactions/derpibooru_api_key" }. Each
+    referenced parameter must already exist as a SecureString.
+  EOT
+  default     = {}
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,6 +1,15 @@
 variable "aws_region" {
   type        = string
-  description = "AWS region for all resources."
+  description = <<-EOT
+    Region for every regional resource in this stack (Lambda, ECR, CloudWatch,
+    SSM, and the state bucket). This is the single knob — you decide; all
+    resources inherit it (IAM is global and unaffected). Default us-east-1: it's
+    AWS's cheapest US region (the pricing baseline) and where the global pieces a
+    future custom domain needs (ACM for CloudFront) must live, avoiding
+    cross-region friction. us-east-2 / us-west-2 cost the same if you prefer one
+    of those. NOTE: the SSM secret parameters must be created in this region, and
+    the state-bucket region in backend.hcl should match.
+  EOT
   default     = "us-east-1"
 }
 
@@ -68,4 +77,36 @@ variable "booru_ssm_parameters" {
     referenced parameter must already exist as a SecureString.
   EOT
   default     = {}
+}
+
+# --- Retention / cost controls ------------------------------------------------
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch Logs retention for the function (a valid CloudWatch value, e.g. 7/14/30/90)."
+  default     = 30
+}
+
+variable "ecr_keep_last_images" {
+  type        = number
+  description = "Keep this many of the most-recent tagged images; older ones are expired."
+  default     = 10
+}
+
+variable "ecr_untagged_expire_days" {
+  type        = number
+  description = "Expire untagged images older than this many days."
+  default     = 7
+}
+
+variable "monthly_budget_usd" {
+  type        = number
+  description = "Monthly AWS Budgets alert limit (USD). 0 (default) creates no budget."
+  default     = 0
+}
+
+variable "budget_alert_emails" {
+  type        = list(string)
+  description = "Emails notified at 80% and 100% of monthly_budget_usd; required to enable the budget."
+  default     = []
 }

--- a/deploy/terraform/versions.tf
+++ b/deploy/terraform/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Remote state in S3 with a DynamoDB lock table. The concrete bucket/table are
+  # supplied at init time via `-backend-config=backend.hcl` (see README), so no
+  # account-specific values are hard-coded here and `init -backend=false` works
+  # in CI. Bootstrap the bucket/table once with deploy/terraform/bootstrap.
+  backend "s3" {}
+}

--- a/deploy/terraform/versions.tf
+++ b/deploy/terraform/versions.tf
@@ -1,16 +1,17 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 
-  # Remote state in S3 with a DynamoDB lock table. The concrete bucket/table are
+  # Remote state in S3 with native S3 locking (`use_lockfile`, GA since
+  # Terraform 1.11 — no DynamoDB table needed). The concrete bucket/key are
   # supplied at init time via `-backend-config=backend.hcl` (see README), so no
   # account-specific values are hard-coded here and `init -backend=false` works
-  # in CI. Bootstrap the bucket/table once with deploy/terraform/bootstrap.
+  # in CI. Bootstrap the bucket once with deploy/terraform/bootstrap.
   backend "s3" {}
 }


### PR DESCRIPTION
## What & why

Repo-owned Terraform for the serverless HTTP-Interactions frontend (epic #28, **issue #30**): an AWS Lambda **container image** behind a **Function URL**, with least-privilege IAM. The Function URL output is what #31 sets as Discord's Interactions Endpoint URL. Decisions confirmed with @auzbuzzard: **container image**, **S3 + DynamoDB** state, **lint-only CI**.

I can't `apply` from CI's environment, but everything is **validated locally with terraform 1.9.8** (`fmt` clean, `validate` OK on both stacks).

## Layout (`deploy/terraform/`)

- **`main.tf`** — ECR repo, IAM role (CloudWatch Logs only), `aws_lambda_function` (arm64, `package_type=Image`, pinned to the image **digest**), `aws_lambda_function_url` (`AUTH_NONE`) + the required public-invoke permission.
- **`secrets.tf`** — reads **out-of-band SSM SecureString** params into the Lambda env: `DISCORD_PUBLIC_KEY` required, optional booru auth via an `ENV_NAME => ssm_name` map. No `DISCORD_TOKEN` (the Lambda never uses it, post-#38).
- **`versions.tf` / `providers.tf` / `variables.tf` / `outputs.tf`** — provider pin, S3 backend (configured at init via `backend.hcl`), inputs, and the `function_url` output.
- **`music.tf`** — commented future stubs: the #35 self-invoke permission and the #33 SQS music bus.
- **`bootstrap/`** — one-time stack (local state) that creates the encrypted+versioned state bucket and the lock table.
- **`../Dockerfile.lambda`** — Lambda image from `public.ecr.aws/lambda/python:3.12`, installs `.[interactions]`, CMD `petbot.frontends.interactions.app.lambda_handler`.
- **`README.md`** — full apply/teardown runbook (bootstrap → SSM params → two-step ECR/image/apply).
- **`.github/workflows/terraform.yml`** — `fmt -check` + `validate` (init `-backend=false`); no AWS creds needed.

## Flag for review (a correction to my earlier #30 note)

My planning comment on #30 said secrets would be kept **out of state**. In this implementation secrets are injected as **Lambda env vars from SSM data sources**, so the decrypted values *do* land in Terraform **state** — the standard pattern that keeps the app 100% `os.environ`/platform-agnostic. Mitigation: the bootstrapped state bucket is **encrypted + versioned + private**. Truly state-free secrets would need the function to **fetch SSM at runtime** (adds boto3 to the adapter); I scoped that out and noted it as a future hardening under secrets/ops #17. Happy to switch approaches if you'd rather keep state secret-free now.

Other notes:
- First apply is a documented **two-step** (create ECR → build/push image → full apply), because the function pins the image digest.
- CI is lint-only; a full **OIDC plan/apply** pipeline is a deliberate follow-up (needs an AWS OIDC role).

## Done when (per #30)
`terraform apply` produces a live Function URL serving the interactions handler — reproducible from the README; the apply itself runs from your AWS account.

Closes #30.

https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZR35H7aWgUw1Xquqc3W85)_