### PR TITLE
Add CI slash-command registration + OIDC deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,9 @@ jobs:
           DISCORD_GUILD_ID: ${{ github.event.inputs.guild_id }}
         run: |
           pip install -e .
-          DISCORD_BOT_TOKEN="$(aws ssm get-parameter \
+          TOKEN="$(aws ssm get-parameter \
             --name /petbot/interactions/discord_bot_token \
-            --with-decryption --query Parameter.Value --output text)" \
-          python -m petbot.frontends.interactions.register
+            --with-decryption --query Parameter.Value --output text)"
+          # Mask it in the Actions log: if anything ever echoes it, it shows as ***.
+          echo "::add-mask::$TOKEN"
+          DISCORD_BOT_TOKEN="$TOKEN" python -m petbot.frontends.interactions.register

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,110 @@
+name: Deploy
+
+# Build + push the arm64 Lambda image, terraform apply, and register the slash
+# commands — entirely from CI via GitHub OIDC (no static AWS keys). See issue #42
+# and deploy/terraform/README.md. The one-time trust bootstrap (OIDC provider +
+# deploy role + state bucket + SSM secrets) is run once from AWS CloudShell.
+on:
+  # Manual run: lets you target a single guild for instant, guild-scoped command
+  # registration (the dev-guild rollout) before going global.
+  workflow_dispatch:
+    inputs:
+      guild_id:
+        description: "Guild ID for instant guild-scoped command registration (blank = global)."
+        required: false
+        default: ""
+  push:
+    branches: [master]
+
+# OIDC: request a short-lived token to assume the AWS deploy role.
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TF_DIR: deploy/terraform
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Optional manual-approval gate; configure required reviewers on the
+    # `production` GitHub Environment to require sign-off before a deploy runs.
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.4"
+
+      - name: Image tag (short git SHA)
+        run: echo "IMAGE_TAG=${GITHUB_SHA::12}" >> "$GITHUB_ENV"
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" \
+            -backend-config="key=interactions/terraform.tfstate" \
+            -backend-config="region=${{ vars.AWS_REGION }}" \
+            -backend-config="encrypt=true" \
+            -backend-config="use_lockfile=true"
+
+      # The function is pinned to the image digest, so the image must exist before
+      # the full apply. Create just the ECR repo first (idempotent on re-runs).
+      - name: Ensure ECR repository exists
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -auto-approve -target=aws_ecr_repository.this
+
+      - name: Build & push arm64 image
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          REPO=$(terraform output -raw ecr_repository_url)
+          echo "ECR_REPO=$REPO" >> "$GITHUB_ENV"
+          aws ecr get-login-password --region "${{ vars.AWS_REGION }}" \
+            | docker login --username AWS --password-stdin "${REPO%%/*}"
+          docker buildx build \
+            --platform linux/arm64 \
+            -f ../Dockerfile.lambda \
+            -t "$REPO:$IMAGE_TAG" \
+            --push \
+            ../..
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -auto-approve -var "image_tag=$IMAGE_TAG"
+
+      - name: Show Function URL
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform output -raw function_url
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # Register the slash commands. The bot token is read from SSM at run time
+      # (never stored in GitHub) and lives only in this step's environment.
+      - name: Register slash commands
+        env:
+          DISCORD_APP_ID: ${{ vars.DISCORD_APP_ID }}
+          DISCORD_GUILD_ID: ${{ github.event.inputs.guild_id }}
+        run: |
+          pip install -e .
+          DISCORD_BOT_TOKEN="$(aws ssm get-parameter \
+            --name /petbot/interactions/discord_bot_token \
+            --with-decryption --query Parameter.Value --output text)" \
+          python -m petbot.frontends.interactions.register

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -24,6 +24,10 @@ The Lambda image is built from [`../Dockerfile.lambda`](../Dockerfile.lambda).
   ```sh
   aws ssm put-parameter --type SecureString \
     --name /petbot/interactions/discord_public_key --value "<application public key>"
+  # Bot token — used ONLY by the CI command-registration step (register.py),
+  # never by the Lambda at request time. Read from SSM in CI; never in GitHub.
+  aws ssm put-parameter --type SecureString \
+    --name /petbot/interactions/discord_bot_token --value "<bot token>"
   # optional booru auth:
   # aws ssm put-parameter --type SecureString --name /petbot/interactions/derpibooru_api_key --value "..."
   ```
@@ -42,6 +46,38 @@ terraform apply -var "state_bucket=petbot-tfstate-<your-account-id>"
 cd ..
 cp backend.hcl.example backend.hcl   # fill in the bucket name
 ```
+
+The bootstrap stack also creates the **GitHub Actions OIDC provider** and the
+**`petbot-github-deploy` IAM role** the CI pipeline assumes (no static AWS keys).
+After applying, wire its outputs as repo **variables** (Settings → Secrets and
+variables → Actions → Variables — non-secret):
+
+```sh
+terraform -chdir=bootstrap output deploy_role_arn   # -> DEPLOY_ROLE_ARN
+```
+
+| GitHub Actions variable | Value |
+| --- | --- |
+| `DEPLOY_ROLE_ARN` | `deploy_role_arn` bootstrap output |
+| `AWS_REGION` | e.g. `us-east-1` (match `backend.hcl` / your SSM region) |
+| `TF_STATE_BUCKET` | the `state_bucket` you chose above |
+| `DISCORD_APP_ID` | your Discord application ID |
+
+## CI deploy (the steady-state path)
+
+`.github/workflows/deploy.yml` does the whole rollout via OIDC — build + push the
+arm64 image (tagged with the git SHA), `terraform apply`, then register the slash
+commands. **No deploy is ever run from a developer machine.**
+
+- **Roll out to one guild first (instant):** run the workflow via
+  *Actions → Deploy → Run workflow* with **`guild_id`** set to your dev/private
+  server's ID. `register.py` registers the commands guild-scoped, so they appear
+  in that guild immediately and nowhere else.
+- **Go global:** a push to `master` runs the same pipeline with an empty
+  `guild_id`, registering the commands application-wide (up to ~1h to propagate).
+- **First run only:** set Discord's *Interactions Endpoint URL* to the
+  `function_url` the workflow prints, and invite the app to the target guild
+  (`bot` + `applications.commands` scopes).
 
 ## Deploy
 
@@ -96,5 +132,6 @@ cd bootstrap && terraform destroy -var "state_bucket=petbot-tfstate-<your-accoun
 ## CI
 
 `.github/workflows/terraform.yml` runs `fmt -check` + `validate` on PRs (no AWS
-credentials needed). `plan`/`apply` are run manually from here for now; a full
-OIDC pipeline can be added later.
+credentials needed). `.github/workflows/deploy.yml` runs the full OIDC
+build/apply/register pipeline (see **CI deploy** above). The manual two-step
+`terraform apply` flow above remains valid for local/break-glass use.

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -38,6 +38,12 @@ variable "github_repo" {
   default     = "auzbuzzard/petbot"
 }
 
+variable "name_prefix" {
+  type        = string
+  description = "Must match var.name_prefix in the root stack; used to scope the deploy role's permissions to exactly that stack's resources."
+  default     = "petbot-interactions"
+}
+
 resource "aws_s3_bucket" "state" {
   bucket = var.state_bucket
 }
@@ -117,10 +123,22 @@ resource "aws_iam_role" "github_deploy" {
   assume_role_policy = data.aws_iam_policy_document.deploy_trust.json
 }
 
-# Permissions the deploy workflow needs: Terraform state in S3, read the runtime
-# secrets in SSM, and manage the interactions stack (Lambda/ECR/role/logs/budget).
-# Wildcarded on the service actions for a single-stack bootstrap; tighten to ARNs
-# if this account ever hosts more than petbot.
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  # Every resource the deploy role may touch is one of the named stack resources
+  # below; scoping to these ARNs means a stolen CI token can't reach anything
+  # else in the account.
+  lambda_arn    = "arn:aws:lambda:${var.aws_region}:${local.account_id}:function:${var.name_prefix}"
+  ecr_repo_arn  = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${var.name_prefix}"
+  log_group_arn = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${var.name_prefix}"
+  exec_role_arn = "arn:aws:iam::${local.account_id}:role/${var.name_prefix}-role"
+}
+
+# Least-privilege permissions for the deploy workflow. Service-level action
+# wildcards (e.g. ecr:*) are kept where enumerating every Terraform-issued call
+# is brittle, but each statement is pinned to this stack's resource ARNs so the
+# role's blast radius is exactly the interactions stack and nothing more.
 data "aws_iam_policy_document" "deploy_permissions" {
   statement {
     sid       = "TerraformState"
@@ -131,18 +149,59 @@ data "aws_iam_policy_document" "deploy_permissions" {
   statement {
     sid       = "ReadRuntimeSecrets"
     actions   = ["ssm:GetParameter", "ssm:GetParameters"]
-    resources = ["arn:aws:ssm:*:${data.aws_caller_identity.current.account_id}:parameter/petbot/interactions/*"]
+    resources = ["arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/petbot/interactions/*"]
+  }
+
+  # SecureString parameters are KMS-encrypted; reading them with decryption needs
+  # kms:Decrypt. Scoped via kms:ViaService so the role can only use KMS through
+  # SSM — never to decrypt arbitrary data directly.
+  statement {
+    sid       = "DecryptSecretsViaSSM"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.aws_region}.amazonaws.com"]
+    }
+  }
+
+  # ECR login is an account-level call with no resource to scope to.
+  statement {
+    sid       = "EcrAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
   }
 
   statement {
-    sid = "ManageInteractionsStack"
+    sid       = "ManageEcrRepo"
+    actions   = ["ecr:*"]
+    resources = [local.ecr_repo_arn]
+  }
+
+  statement {
+    sid       = "ManageLambda"
+    actions   = ["lambda:*"]
+    resources = [local.lambda_arn, "${local.lambda_arn}:*"]
+  }
+
+  statement {
+    sid       = "ManageLogs"
+    actions   = ["logs:*"]
+    resources = [local.log_group_arn, "${local.log_group_arn}:*"]
+  }
+
+  statement {
+    sid       = "ManageBudget"
+    actions   = ["budgets:*"]
+    resources = ["arn:aws:budgets::${local.account_id}:budget/*"]
+  }
+
+  # Create/manage only the Lambda execution role this stack owns.
+  statement {
+    sid = "ManageExecRole"
     actions = [
-      "lambda:*",
-      "ecr:*",
-      "logs:*",
-      "budgets:*",
       "iam:GetRole",
-      "iam:PassRole",
       "iam:CreateRole",
       "iam:DeleteRole",
       "iam:AttachRolePolicy",
@@ -152,10 +211,24 @@ data "aws_iam_policy_document" "deploy_permissions" {
       "iam:GetRolePolicy",
       "iam:ListRolePolicies",
       "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
       "iam:TagRole",
       "iam:UntagRole",
     ]
-    resources = ["*"]
+    resources = [local.exec_role_arn]
+  }
+
+  # PassRole is the classic privilege-escalation lever, so it is doubly fenced:
+  # only the one exec role, and only when handed to the Lambda service.
+  statement {
+    sid       = "PassExecRoleToLambda"
+    actions   = ["iam:PassRole"]
+    resources = [local.exec_role_arn]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["lambda.amazonaws.com"]
+    }
   }
 }
 

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -32,6 +32,12 @@ variable "state_bucket" {
   description = "Globally-unique S3 bucket name for Terraform state."
 }
 
+variable "github_repo" {
+  type        = string
+  description = "owner/name of the repo allowed to assume the deploy role via OIDC."
+  default     = "auzbuzzard/petbot"
+}
+
 resource "aws_s3_bucket" "state" {
   bucket = var.state_bucket
 }
@@ -65,4 +71,101 @@ resource "aws_s3_bucket_public_access_block" "state" {
 
 output "state_bucket" {
   value = aws_s3_bucket.state.id
+}
+
+# --- GitHub Actions OIDC: the one irreducible bit of trust --------------------
+# CI cannot bootstrap its own trust: AWS must already trust GitHub before any
+# workflow can assume a role. This (and the SSM secrets) is the single manual,
+# in-browser CloudShell step; after it, 100% of deploys are CI.
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS validates GitHub's OIDC cert against its trust store now, but the
+  # argument is still required; this is GitHub's documented thumbprint.
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Trust policy: only this repo's workflows (any ref) may assume the role.
+data "aws_iam_policy_document" "deploy_trust" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_deploy" {
+  name               = "petbot-github-deploy"
+  assume_role_policy = data.aws_iam_policy_document.deploy_trust.json
+}
+
+# Permissions the deploy workflow needs: Terraform state in S3, read the runtime
+# secrets in SSM, and manage the interactions stack (Lambda/ECR/role/logs/budget).
+# Wildcarded on the service actions for a single-stack bootstrap; tighten to ARNs
+# if this account ever hosts more than petbot.
+data "aws_iam_policy_document" "deploy_permissions" {
+  statement {
+    sid       = "TerraformState"
+    actions   = ["s3:ListBucket", "s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [aws_s3_bucket.state.arn, "${aws_s3_bucket.state.arn}/*"]
+  }
+
+  statement {
+    sid       = "ReadRuntimeSecrets"
+    actions   = ["ssm:GetParameter", "ssm:GetParameters"]
+    resources = ["arn:aws:ssm:*:${data.aws_caller_identity.current.account_id}:parameter/petbot/interactions/*"]
+  }
+
+  statement {
+    sid = "ManageInteractionsStack"
+    actions = [
+      "lambda:*",
+      "ecr:*",
+      "logs:*",
+      "budgets:*",
+      "iam:GetRole",
+      "iam:PassRole",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:TagRole",
+      "iam:UntagRole",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_deploy" {
+  name   = "deploy"
+  role   = aws_iam_role.github_deploy.id
+  policy = data.aws_iam_policy_document.deploy_permissions.json
+}
+
+output "deploy_role_arn" {
+  description = "Set as the DEPLOY_ROLE_ARN GitHub Actions variable."
+  value       = aws_iam_role.github_deploy.arn
 }

--- a/petbot/frontends/interactions/commands.py
+++ b/petbot/frontends/interactions/commands.py
@@ -1,0 +1,120 @@
+"""Slash-command definitions for the HTTP-Interactions app.
+
+Discord stores slash commands **per application**, not per transport, and the
+interactions Lambda only *handles* commands at request time (see
+:mod:`.handler`) — it never registers them. This module is that missing piece:
+the single, declarative source of truth for what :mod:`.register` PUTs to
+Discord.
+
+It is deliberately ``discord``-free — plain dicts in Discord's
+application-command schema (``CHAT_INPUT`` type, numeric option types) — so it
+stays importable on the minimal Lambda runtime and obeys the same core/adapter
+import boundary as the rest of ``petbot.frontends.interactions`` (enforced by
+import-linter).
+
+Each entry mirrors what :class:`~petbot.frontends.interactions.handler.InteractionHandler`
+dispatches: one command per interactions-available skill (``/math``, ``/derpi``,
+``/e621``), plus the adapter-level ``/ping``. Option ``name`` keys match the keys
+each skill reads from ``args`` and the properties of its ``input_schema``; the
+``tests/test_interactions_commands.py`` guardrail fails if the two ever drift.
+``/music`` is absent because it requires the voice capability the interactions
+frontend does not advertise; ``/purge`` is not yet wired on this path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+# Discord application-command type (only chat-input/slash commands here).
+# https://discord.com/developers/docs/interactions/application-commands
+CHAT_INPUT: Final = 1
+
+# Application-command option types we use.
+_STRING: Final = 3
+_INTEGER: Final = 4
+_BOOLEAN: Final = 5
+
+# NOTE: Discord requires every required option to precede the optional ones; the
+# guardrail test enforces this ordering so a reorder can't silently break the PUT.
+COMMANDS: Final[list[dict[str, Any]]] = [
+    {
+        "type": CHAT_INPUT,
+        "name": "ping",
+        "description": "Liveness check.",
+        "options": [],
+    },
+    {
+        "type": CHAT_INPUT,
+        "name": "math",
+        "description": "Evaluate a mathematical expression.",
+        "options": [
+            {
+                "type": _STRING,
+                "name": "expression",
+                "description": "The arithmetic expression to evaluate, e.g. '2 * 21'.",
+                "required": True,
+            },
+        ],
+    },
+    {
+        "type": CHAT_INPUT,
+        "name": "derpi",
+        "description": "Search Derpibooru for an image.",
+        "options": [
+            {
+                "type": _STRING,
+                "name": "tags",
+                "description": "Comma-separated tags (spaces allowed within a tag).",
+                "required": True,
+            },
+            {
+                "type": _STRING,
+                "name": "sort",
+                "description": "How to order matches before picking one.",
+            },
+            {
+                "type": _BOOLEAN,
+                "name": "descending",
+                "description": "Sort descending (default) or ascending.",
+            },
+            {
+                "type": _STRING,
+                "name": "file_type",
+                "description": "Restrict results to a file type.",
+            },
+            {
+                "type": _INTEGER,
+                "name": "min_score",
+                "description": "Only results with at least this score.",
+            },
+        ],
+    },
+    {
+        "type": CHAT_INPUT,
+        "name": "e621",
+        "description": "Search e621 for an image.",
+        "options": [
+            {
+                "type": _STRING,
+                "name": "tags",
+                "description": "Space-separated tags (use underscores within a tag).",
+                "required": True,
+            },
+            {
+                "type": _STRING,
+                "name": "sort",
+                "description": "How to order matches before picking one.",
+            },
+            {
+                "type": _STRING,
+                "name": "file_type",
+                "description": "Restrict results to a file type.",
+            },
+            {
+                "type": _INTEGER,
+                "name": "min_score",
+                "description": "Only results with at least this score.",
+            },
+        ],
+    },
+]

--- a/petbot/frontends/interactions/register.py
+++ b/petbot/frontends/interactions/register.py
@@ -1,0 +1,101 @@
+"""Register the interactions app's slash commands with Discord.
+
+Run from CI (never a developer machine); see ``.github/workflows/deploy.yml``.
+Because Discord stores commands per *application*, registration is a single
+**bulk-overwrite PUT** of :data:`~petbot.frontends.interactions.commands.COMMANDS`
+— idempotent and declarative: the PUT replaces whatever was there, so re-running
+it on every deploy only changes Discord when the command set changes.
+
+Scope:
+
+* ``DISCORD_GUILD_ID`` set  -> guild-scoped registration. Appears **instantly**
+  in just that guild — the dev-guild rollout path.
+* ``DISCORD_GUILD_ID`` unset -> global registration. App-wide, but Discord may
+  take up to ~1 hour to propagate it everywhere.
+
+Auth uses the bot token (``Authorization: Bot ...``). The Lambda never needs the
+token at request time (it verifies only the Ed25519 signature), so it lives in
+SSM and is exported into this process by CI — it is never written to disk.
+
+Run::
+
+    python -m petbot.frontends.interactions.register
+
+Required env: ``DISCORD_APP_ID``, ``DISCORD_BOT_TOKEN``.
+Optional env: ``DISCORD_GUILD_ID`` (guild-scoped when present), ``LOG_LEVEL``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from petbot.frontends.interactions.commands import COMMANDS
+from petbot.logging_setup import configure_logging
+
+logger = logging.getLogger(__name__)
+
+#: Discord REST API base. v10 is the current stable application-commands API.
+API_BASE = "https://discord.com/api/v10"
+
+#: How long to wait on the single PUT before giving up.
+_TIMEOUT_SECONDS = 30.0
+
+
+class RegisterError(RuntimeError):
+    """Raised when registration cannot run or Discord rejects the request."""
+
+
+def _endpoint(app_id: str, guild_id: str | None) -> str:
+    """The bulk-overwrite URL: guild-scoped when ``guild_id`` is given, else global."""
+    if guild_id:
+        return f"{API_BASE}/applications/{app_id}/guilds/{guild_id}/commands"
+    return f"{API_BASE}/applications/{app_id}/commands"
+
+
+def register(app_id: str, bot_token: str, guild_id: str | None = None) -> list[dict[str, Any]]:
+    """PUT the full command set to Discord and return the registered commands.
+
+    Raises :class:`RegisterError` on any non-2xx response. The bot token is sent
+    only in the ``Authorization`` header and is never logged.
+    """
+    response = httpx.put(
+        _endpoint(app_id, guild_id),
+        headers={"Authorization": f"Bot {bot_token}"},
+        json=COMMANDS,
+        timeout=_TIMEOUT_SECONDS,
+    )
+    if response.is_error:
+        # response.text is Discord's error JSON — it never echoes the token.
+        raise RegisterError(
+            f"Discord rejected command registration ({response.status_code}): {response.text}"
+        )
+    registered: list[dict[str, Any]] = response.json()
+    return registered
+
+
+def main() -> None:
+    """Entry point: read config from the environment and register the commands."""
+    configure_logging(level=os.environ.get("LOG_LEVEL", "INFO"), fmt="plain")
+
+    app_id = os.environ.get("DISCORD_APP_ID", "").strip()
+    bot_token = os.environ.get("DISCORD_BOT_TOKEN", "").strip()
+    guild_id = os.environ.get("DISCORD_GUILD_ID", "").strip() or None
+    if not app_id or not bot_token:
+        raise RegisterError("DISCORD_APP_ID and DISCORD_BOT_TOKEN are both required.")
+
+    scope = f"guild {guild_id}" if guild_id else "global"
+    registered = register(app_id, bot_token, guild_id)
+    logger.info(
+        "Registered %d command(s) (%s): %s",
+        len(registered),
+        scope,
+        ", ".join(command["name"] for command in COMMANDS),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_interactions_commands.py
+++ b/tests/test_interactions_commands.py
@@ -1,0 +1,115 @@
+"""Guardrails for the interactions slash-command definitions and registration.
+
+The command specs in :mod:`petbot.frontends.interactions.commands` are authored
+by hand (Discord's schema), so these tests keep them honest against the two
+things that can drift out from under them: the set of skills the interactions
+frontend actually exposes, and each skill's ``input_schema``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from petbot.core.skills.booru_skill import DerpiSkill, E621Skill
+from petbot.core.skills.math_skill import MathSkill
+from petbot.core.skills.music_skill import MusicSkill
+from petbot.core.skills.registry import SkillRegistry
+from petbot.frontends.interactions.app import INTERACTIONS_CAPABILITIES
+from petbot.frontends.interactions.commands import COMMANDS
+from petbot.frontends.interactions.register import API_BASE, RegisterError, register
+
+
+# Skills wired into the interactions handler (mirrors app.build_handler), used to
+# derive the expected command surface from the real registry rather than a
+# hand-maintained list.
+async def _interactions_skill_names() -> set[str]:
+    async with httpx.AsyncClient() as client:
+        registry = SkillRegistry(
+            [
+                MathSkill(),
+                DerpiSkill(client=client),
+                E621Skill(client=client, user_agent="test"),
+                MusicSkill(),
+            ]
+        )
+        return {skill.name for skill in registry.available_for(INTERACTIONS_CAPABILITIES)}
+
+
+# input_schema lives on the skill *class*, so no instance/client is needed here.
+_SCHEMA_BY_NAME: dict[str, Any] = {
+    "math": MathSkill.input_schema,
+    "derpi": DerpiSkill.input_schema,
+    "e621": E621Skill.input_schema,
+}
+
+
+async def test_commands_cover_exactly_the_interactions_surface() -> None:
+    names = {command["name"] for command in COMMANDS}
+    # Every interactions-available skill is registered, plus the adapter-level
+    # /ping — and nothing else (so /music, which is voice-gated, stays absent).
+    assert names == await _interactions_skill_names() | {"ping"}
+
+
+def test_ping_takes_no_options() -> None:
+    (ping,) = (command for command in COMMANDS if command["name"] == "ping")
+    assert ping["options"] == []
+
+
+def test_options_match_each_skill_schema() -> None:
+    for command in COMMANDS:
+        if command["name"] == "ping":
+            continue
+        schema = _SCHEMA_BY_NAME[command["name"]]
+        option_names = {option["name"] for option in command["options"]}
+        required_names = {opt["name"] for opt in command["options"] if opt.get("required")}
+
+        # Every option must be a real schema property, and the required options
+        # must be exactly the schema's required keys.
+        assert option_names <= set(schema["properties"])
+        assert required_names == set(schema["required"])
+
+
+def test_required_options_precede_optional() -> None:
+    # Discord rejects a command whose required options come after an optional one.
+    for command in COMMANDS:
+        seen_optional = False
+        for option in command["options"]:
+            if option.get("required"):
+                assert not seen_optional, f"{command['name']}: required option after optional"
+            else:
+                seen_optional = True
+
+
+@respx.mock
+def test_register_targets_the_guild_endpoint_when_a_guild_is_given() -> None:
+    route = respx.put(f"{API_BASE}/applications/app123/guilds/guild456/commands").mock(
+        return_value=httpx.Response(200, json=COMMANDS)
+    )
+    result = register("app123", "tok", guild_id="guild456")
+
+    assert route.called
+    assert route.calls.last.request.headers["Authorization"] == "Bot tok"
+    assert len(result) == len(COMMANDS)
+
+
+@respx.mock
+def test_register_targets_the_global_endpoint_without_a_guild() -> None:
+    route = respx.put(f"{API_BASE}/applications/app123/commands").mock(
+        return_value=httpx.Response(200, json=COMMANDS)
+    )
+    register("app123", "tok")
+
+    assert route.called
+
+
+@respx.mock
+def test_register_raises_on_a_discord_error() -> None:
+    respx.put(f"{API_BASE}/applications/app123/commands").mock(
+        return_value=httpx.Response(403, json={"message": "Missing Access", "code": 50001})
+    )
+    with pytest.raises(RegisterError, match="403"):
+        register("app123", "tok")


### PR DESCRIPTION
## Why

I want to roll out the serverless (interactions Lambda) bot to **one Discord server first** — my private/dev guild — before it goes public, without ever deploying from a laptop. Issue #42 designs the prod CI pipeline but (a) had no command-registration step and (b) was prod-only. The interactions Lambda **handles** commands at request time but nothing ever **registered** them with Discord (the gateway was the only registrar, and the gateway is dead). This PR adds the missing registration piece and a guild-first CI rollout.

## What

- **`petbot/frontends/interactions/commands.py`** — declarative, `discord`-free source of truth for the app's slash commands (`ping`/`math`/`derpi`/`e621`) in Discord's application-command schema. `/music` is absent (voice-gated); `/purge` is not wired on this path yet.
- **`petbot/frontends/interactions/register.py`** — bulk-overwrite PUT to Discord. **Guild-scoped when `DISCORD_GUILD_ID` is set** (instant, single-guild rollout), else global. Bot token comes from the environment, is sent only in the `Authorization` header, and is never logged or written to disk.
- **`tests/test_interactions_commands.py`** — guardrails: the registered command surface equals the interactions registry's available skills `+ ping`; required options match each skill's `input_schema`; required options precede optional (Discord rule); registration hits the right endpoint and raises on Discord errors.
- **`.github/workflows/deploy.yml`** — OIDC build/push (arm64) → `terraform apply` → register. A `workflow_dispatch` **`guild_id`** input does the guild-first rollout; a push to `master` registers globally.
- **`deploy/terraform/bootstrap/`** — GitHub OIDC provider + `petbot-github-deploy` role (trust scoped to `repo:auzbuzzard/petbot`, least-privilege permissions) + `deploy_role_arn` output.
- **Docs** — new `discord_bot_token` SSM secret, the OIDC bootstrap, required GitHub Actions variables, and the CI deploy flow.

## Runbook (guild-first rollout)

One-time (browser / CloudShell):
1. `terraform apply` the bootstrap → creates state bucket, OIDC provider, deploy role, role ARN output.
2. Put SSM secrets: `/petbot/interactions/discord_public_key`, `/petbot/interactions/discord_bot_token`.
3. Set GitHub Actions variables: `DEPLOY_ROLE_ARN`, `AWS_REGION`, `TF_STATE_BUCKET`, `DISCORD_APP_ID`.
4. Invite the app to your private guild (`bot` + `applications.commands`).

Per rollout (CI):
5. *Actions → Deploy → Run workflow* with **`guild_id` = your private guild** → builds, applies, registers guild-scoped (instant).
6. First run only: set Discord's *Interactions Endpoint URL* to the `function_url` the workflow prints.
7. Test in the private guild. When happy, push to `master` (or re-run without `guild_id`) to go global.

## Validated

`ruff` (lint + format), `mypy --strict`, `lint-imports` (interactions stays `discord`-free), and `pytest` (103 passed, 2 skipped) all green on 3.12.

## NOT validated — needs your eyes / AWS

- **Terraform is unvalidated** — no `terraform` binary in this environment, and no AWS to plan/apply against. The OIDC provider, trust policy, and IAM permissions are written carefully but the permissions are wildcarded on `lambda:*`/`ecr:*`/`iam:*` for a single-stack bootstrap; tighten to ARNs if desired. Please `terraform plan` the bootstrap before applying.
- **The actual AWS/Discord steps are yours** — I can't click CloudShell or the Developer Portal. The browser one-time steps above are unavoidable (CI can't bootstrap its own trust).
- **ECR stays in the main stack** (not moved into bootstrap as #42 proposes); the workflow's `apply -target=aws_ecr_repository.this` handles the build-before-apply ordering. Moving it is a separate, state-migration-touching change.

https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF)_