### PR TITLE
Make deploy pipeline environment-aware (dev/prod), additive only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,13 @@ on:
   # registration (the dev-guild rollout) before going global.
   workflow_dispatch:
     inputs:
+      environment:
+        description: "Target deploy environment (resolves per-environment variables + state key)."
+        type: choice
+        options:
+          - production
+          - dev
+        default: production
       guild_id:
         description: "Guild ID for instant guild-scoped command registration (blank = global)."
         required: false
@@ -27,13 +34,19 @@ concurrency:
 
 env:
   TF_DIR: deploy/terraform
+  # Target environment, computed once: a manual run uses the chosen input; a push
+  # to master always deploys `production`. Per-environment GitHub Environment
+  # variables (DEPLOY_ROLE_ARN, DISCORD_APP_ID) resolve against this; the state
+  # key and resource name_prefix are namespaced for non-prod (prod is unchanged).
+  DEPLOY_ENV: ${{ github.event.inputs.environment || 'production' }}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Optional manual-approval gate; configure required reviewers on the
-    # `production` GitHub Environment to require sign-off before a deploy runs.
-    environment: production
+    # Optional manual-approval gate; configure required reviewers on the selected
+    # GitHub Environment to require sign-off before a deploy runs. A push to
+    # master resolves to `production` (matching DEPLOY_ENV above).
+    environment: ${{ github.event.inputs.environment || 'production' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,12 +66,30 @@ jobs:
       - name: Image tag (short git SHA)
         run: echo "IMAGE_TAG=${GITHUB_SHA::12}" >> "$GITHUB_ENV"
 
+      # Per-environment state-key + name_prefix. production stays byte-identical
+      # to today (key interactions/terraform.tfstate, prefix petbot-interactions)
+      # so the live state and the existing scoped deploy role are never orphaned;
+      # any other env is namespaced under interactions/<env>/.
+      - name: Resolve environment-scoped Terraform inputs
+        run: |
+          if [ "$DEPLOY_ENV" = "production" ]; then
+            echo "TF_STATE_KEY=interactions/terraform.tfstate" >> "$GITHUB_ENV"
+            echo "TF_NAME_PREFIX=petbot-interactions" >> "$GITHUB_ENV"
+            # The app keys is_prod (and thus JSON logging) on ENV == "prod", so
+            # production keeps lambda_environment=prod unchanged from today.
+            echo "TF_LAMBDA_ENV=prod" >> "$GITHUB_ENV"
+          else
+            echo "TF_STATE_KEY=interactions/${DEPLOY_ENV}/terraform.tfstate" >> "$GITHUB_ENV"
+            echo "TF_NAME_PREFIX=petbot-interactions-${DEPLOY_ENV}" >> "$GITHUB_ENV"
+            echo "TF_LAMBDA_ENV=${DEPLOY_ENV}" >> "$GITHUB_ENV"
+          fi
+
       - name: Terraform init
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform init \
             -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" \
-            -backend-config="key=interactions/terraform.tfstate" \
+            -backend-config="key=${TF_STATE_KEY}" \
             -backend-config="region=${{ vars.AWS_REGION }}" \
             -backend-config="encrypt=true" \
             -backend-config="use_lockfile=true"
@@ -67,7 +98,7 @@ jobs:
       # the full apply. Create just the ECR repo first (idempotent on re-runs).
       - name: Ensure ECR repository exists
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -target=aws_ecr_repository.this
+        run: terraform apply -auto-approve -var "name_prefix=$TF_NAME_PREFIX" -target=aws_ecr_repository.this
 
       - name: Build & push arm64 image
         working-directory: ${{ env.TF_DIR }}
@@ -85,7 +116,11 @@ jobs:
 
       - name: Terraform apply
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -var "image_tag=$IMAGE_TAG"
+        run: |
+          terraform apply -auto-approve \
+            -var "image_tag=$IMAGE_TAG" \
+            -var "name_prefix=$TF_NAME_PREFIX" \
+            -var "lambda_environment=$TF_LAMBDA_ENV"
 
       - name: Show Function URL
         working-directory: ${{ env.TF_DIR }}

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -49,19 +49,86 @@ cp backend.hcl.example backend.hcl   # fill in the bucket name
 
 The bootstrap stack also creates the **GitHub Actions OIDC provider** and the
 **`petbot-github-deploy` IAM role** the CI pipeline assumes (no static AWS keys).
-After applying, wire its outputs as repo **variables** (Settings → Secrets and
-variables → Actions → Variables — non-secret):
+After applying, wire its outputs as **variables** (Settings → Secrets and
+variables → Actions → Variables — non-secret).
+
+## Variable matrix: Repository vs Environment
+
+The deploy supports a `production` / `dev` environment axis (see
+**Environments** below). The guiding principle is simple:
+
+> **A value lives in a GitHub _Environment_ iff it differs per environment.
+> Everything that is the same across environments stays a _Repository_ variable.**
+
+| GitHub variable | Scope | Value | Why this scope |
+| --- | --- | --- | --- |
+| `AWS_REGION` | **Repository** | e.g. `us-east-1` (match `backend.hcl` / your SSM region) | Same region for every env |
+| `TF_STATE_BUCKET` | **Repository** | the `state_bucket` you chose above | One state bucket, per-env *key* (see below) |
+| `DEPLOY_ROLE_ARN` | **Environment** | `deploy_role_arn` bootstrap output for that env | Each env has its own scoped deploy role |
+| `DISCORD_APP_ID` | **Environment** | that env's Discord application ID | Each env is a distinct Discord app |
 
 ```sh
-terraform -chdir=bootstrap output deploy_role_arn   # -> DEPLOY_ROLE_ARN
+terraform -chdir=bootstrap output deploy_role_arn   # -> DEPLOY_ROLE_ARN (per env)
 ```
 
-| GitHub Actions variable | Value |
-| --- | --- |
-| `DEPLOY_ROLE_ARN` | `deploy_role_arn` bootstrap output |
-| `AWS_REGION` | e.g. `us-east-1` (match `backend.hcl` / your SSM region) |
-| `TF_STATE_BUCKET` | the `state_bucket` you chose above |
-| `DISCORD_APP_ID` | your Discord application ID |
+The workflow reads `vars.DEPLOY_ROLE_ARN` / `vars.DISCORD_APP_ID` exactly as
+before — but because they are now **Environment** variables and the job sets
+`environment: <selected env>`, GitHub resolves each to that environment's value.
+`AWS_REGION` / `TF_STATE_BUCKET` resolve from the repository as before.
+
+## Environments (production / dev)
+
+The deploy is environment-aware while keeping **production byte-identical to
+today**:
+
+- **Target selection.** A push to `master` always deploys `production`. A manual
+  *Run workflow* picks `production` (default) or `dev` via the `environment`
+  input. The chosen value is the GitHub `environment:` for the job (resolving the
+  Environment variables above).
+- **Per-env state key** (one bucket, distinct keys):
+  - `production` → `interactions/terraform.tfstate` *(unchanged)*
+  - any other env → `interactions/<env>/terraform.tfstate`
+- **Per-env resource names** (`name_prefix`):
+  - `production` → `petbot-interactions` *(unchanged)*
+  - non-prod → `petbot-interactions-<env>`
+- **Lambda `ENV`** (`lambda_environment`): `production` maps to `prod` (so the
+  app's `is_prod` / JSON-logging behaviour is unchanged); non-prod uses the env
+  name.
+
+Because prod's state key, `name_prefix`, resource names, and `lambda_environment`
+all stay exactly as they are now, a prod deploy is a no-op against the existing
+state and the existing `petbot-github-deploy` role.
+
+## Provisioning a new `dev` environment
+
+`dev` is purely additive — nothing here is required for prod. To stand it up:
+
+1. **Create the GitHub Environment** `dev` (Settings → Environments → New).
+2. **Bootstrap dev's AWS trust** (same account as prod). The OIDC provider is
+   account-global and already owned by the prod bootstrap, so dev must **not**
+   recreate it — pass `manage_oidc_provider=false` and a distinct role name:
+
+   ```sh
+   cd bootstrap
+   terraform apply \
+     -var "state_bucket=petbot-tfstate-<account-id>" \
+     -var "name_prefix=petbot-interactions-dev" \
+     -var "deploy_role_name=petbot-interactions-dev-github-deploy" \
+     -var "manage_oidc_provider=false"
+   ```
+
+   This produces a **distinct** deploy role scoped to the `petbot-interactions-dev`
+   ARNs, referencing the existing provider by its deterministic ARN. (The prod
+   bootstrap keeps `deploy_role_name` at its default `petbot-github-deploy` and
+   `manage_oidc_provider=true`; a `moved` block migrates the provider's state
+   address so prod's plan stays a no-op.)
+3. **Set the two Environment variables** on `dev`: `DEPLOY_ROLE_ARN`
+   (`terraform -chdir=bootstrap output deploy_role_arn` from the dev apply) and
+   `DISCORD_APP_ID` (the dev Discord app's ID).
+4. **Create a separate dev Discord application** (its own bot token + public
+   key) and put its SSM SecureString secrets in place for the dev stack.
+5. **Run the workflow** with `environment=dev` (optionally a `guild_id` for
+   instant guild-scoped command registration).
 
 ## CI deploy (the steady-state path)
 

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -44,6 +44,28 @@ variable "name_prefix" {
   default     = "petbot-interactions"
 }
 
+# Deploy-role name is an explicit variable (NOT derived from name_prefix) so the
+# existing prod role keeps its exact current name `petbot-github-deploy` even
+# though prod's name_prefix is `petbot-interactions`. A second environment passes
+# a distinct name (e.g. `petbot-interactions-dev-github-deploy`) to provision its
+# own role + scoped permissions without clobbering prod's.
+variable "deploy_role_name" {
+  type        = string
+  description = "IAM role name for the CI deploy role. Default keeps the existing prod role; override per non-prod env."
+  default     = "petbot-github-deploy"
+}
+
+# The GitHub OIDC provider is account-global: exactly one
+# `token.actions.githubusercontent.com` provider can exist per account, and prod
+# bootstrap already created it. A second environment in the SAME account must NOT
+# try to create a duplicate — set this to false there and the role's trust policy
+# references the existing provider by its (deterministic) ARN instead.
+variable "manage_oidc_provider" {
+  type        = bool
+  description = "Whether THIS apply owns the account-global GitHub OIDC provider. true for the first/prod bootstrap; false for additional same-account envs."
+  default     = true
+}
+
 resource "aws_s3_bucket" "state" {
   bucket = var.state_bucket
 }
@@ -86,12 +108,31 @@ output "state_bucket" {
 
 data "aws_caller_identity" "current" {}
 
+# Owned by the first/prod bootstrap only (manage_oidc_provider = true). Account
+# can hold exactly one provider for this URL, so additional same-account envs
+# reference the existing one instead of recreating it.
 resource "aws_iam_openid_connect_provider" "github" {
+  count          = var.manage_oidc_provider ? 1 : 0
   url            = "https://token.actions.githubusercontent.com"
   client_id_list = ["sts.amazonaws.com"]
   # AWS validates GitHub's OIDC cert against its trust store now, but the
   # argument is still required; this is GitHub's documented thumbprint.
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# Adding `count` above re-indexes the resource address from `.github` to
+# `.github[0]`. This `moved` block migrates the EXISTING prod state entry to the
+# new address automatically, so prod's next `terraform plan` is a true no-op
+# (no destroy/recreate of the live OIDC provider) with no manual `state mv`.
+moved {
+  from = aws_iam_openid_connect_provider.github
+  to   = aws_iam_openid_connect_provider.github[0]
+}
+
+locals {
+  # The provider ARN is deterministic for a given account, so non-managing envs
+  # can reference the already-existing provider without a data lookup or import.
+  oidc_provider_arn = var.manage_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
 }
 
 # Trust policy: only this repo's workflows (any ref) may assume the role.
@@ -101,7 +142,7 @@ data "aws_iam_policy_document" "deploy_trust" {
 
     principals {
       type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.github.arn]
+      identifiers = [local.oidc_provider_arn]
     }
 
     condition {
@@ -119,7 +160,7 @@ data "aws_iam_policy_document" "deploy_trust" {
 }
 
 resource "aws_iam_role" "github_deploy" {
-  name               = "petbot-github-deploy"
+  name               = var.deploy_role_name
   assume_role_policy = data.aws_iam_policy_document.deploy_trust.json
 }
 


### PR DESCRIPTION
## Summary

Adds a `production` / `dev` **environment axis** to the deploy pipeline as **purely additive wiring**. Nothing here is required for the production deploy — it only opens the door to standing up a `dev` environment later.

## The additive env axis

- **Target selection** is computed once (`DEPLOY_ENV`): a manual *Run workflow* picks `production` (default) or `dev` via a new `environment` choice input; a push to `master` always resolves to `production`. The job's `environment:` is set to the selected value so per-environment GitHub variables resolve.
- **State key**: `production` → `interactions/terraform.tfstate`; any other env → `interactions/<env>/terraform.tfstate` (one bucket, distinct keys).
- **Resource names** (`name_prefix`): `production` → `petbot-interactions`; non-prod → `petbot-interactions-<env>`.
- **Lambda `ENV`** (`lambda_environment`): `production` maps to `prod` so the app's `is_prod` / JSON-logging behaviour is preserved; non-prod uses the env name.

## Production is guaranteed unchanged

For `production`, the state key, `name_prefix`, resource names, and `lambda_environment` (`prod`) are all **byte-identical to today**, so:

- The live state at `interactions/terraform.tfstate` and the existing `petbot-interactions`-scoped `petbot-github-deploy` role are never orphaned.
- A prod `terraform apply` is a **no-op** against existing infra.
- In the bootstrap stack, adding `count`/`deploy_role_name` would re-index the OIDC provider's state address — a `moved` block migrates it automatically, so **`terraform plan` for prod shows no changes** (no destroy/recreate of the live account-global OIDC provider, no manual `state mv`).

A push to `master` today behaves exactly as before.

## Variable matrix

Principle: a value lives in a GitHub **Environment** iff it differs per environment; otherwise it stays a **Repository** variable. No change to how the workflow references them.

| Variable | Scope | Why |
| --- | --- | --- |
| `AWS_REGION` | Repository | same region for every env |
| `TF_STATE_BUCKET` | Repository | one bucket, per-env state *key* |
| `DEPLOY_ROLE_ARN` | Environment | each env has its own scoped deploy role |
| `DISCORD_APP_ID` | Environment | each env is a distinct Discord app |

## What remains manual when provisioning `dev`

1. Create the GitHub Environment `dev`.
2. Run the bootstrap with `name_prefix=petbot-interactions-dev`, `deploy_role_name=petbot-interactions-dev-github-deploy`, and `manage_oidc_provider=false` (the account-global OIDC provider already exists; dev references it, never recreates it).
3. Set the two Environment variables (`DEPLOY_ROLE_ARN`, `DISCORD_APP_ID`) on `dev`.
4. Create a separate dev Discord app and put its SSM SecureString secrets in place.

> Note: the CI command-registration step still reads the bot token from the fixed SSM path `/petbot/interactions/discord_bot_token`. Namespacing that per-env (and the other SSM secret paths) is left as a follow-up for the dev rollout and is out of scope for this additive wiring.

## Validation

- `terraform fmt -check -recursive deploy/terraform` — pass
- `terraform validate` (root + bootstrap, `-backend=false` init) — both pass
- Workflow YAML parses (`yaml.safe_load`) — pass
- `ruff check`, `ruff format --check`, `mypy`, `lint-imports`, `pytest` — all pass (103 passed, 2 skipped)

https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF)_