### PR TITLE
Grant logs:DescribeLogGroups on * to the deploy role

### DIFF
--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -191,6 +191,16 @@ data "aws_iam_policy_document" "deploy_permissions" {
     resources = [local.log_group_arn, "${local.log_group_arn}:*"]
   }
 
+  # logs:DescribeLogGroups is a list operation that AWS only authorizes on "*"
+  # (it has no per-log-group resource form). Terraform calls it to check whether
+  # the log group already exists, so it must be granted account-wide — it's a
+  # read-only listing, so the blast radius is just visibility of log-group names.
+  statement {
+    sid       = "DescribeLogGroups"
+    actions   = ["logs:DescribeLogGroups"]
+    resources = ["*"]
+  }
+
   statement {
     sid       = "ManageBudget"
     actions   = ["budgets:*"]


### PR DESCRIPTION
## Problem

The first production deploy ([run](https://github.com/auzbuzzard/petbot/actions/runs/27604463699)) failed at `terraform apply`:

```
Error: reading CloudWatch Logs Log Group (/aws/lambda/petbot-interactions): ...
api error AccessDeniedException: User: arn:aws:sts::…:assumed-role/petbot-github-deploy/GitHubActions
is not authorized to perform: logs:DescribeLogGroups on resource: arn:aws:logs:…:log-group::log-stream:
```

The deploy role's `ManageLogs` statement scopes `logs:*` to the log-group ARN, but **`logs:DescribeLogGroups` is a list operation AWS only authorizes on `"*"`** — it has no per-log-group resource form. Terraform's `aws_cloudwatch_log_group` calls it to check existence, so the scoped policy denied it. This is the resource-scoping tradeoff flagged in the original review surfacing in practice.

## Fix

Add a dedicated read-only `DescribeLogGroups` statement on `*`. Everything else stays resource-scoped — the only widened privilege is the ability to *list* log-group names, no read/write of contents.

`terraform fmt -check` + `validate` (bootstrap) pass.

## To apply (the role already exists, so re-apply the bootstrap)

From the existing CloudShell clone (keeps local bootstrap state):
```sh
cd ~/petbot && git fetch origin && git checkout claude/fix-deploy-logs-perm
cd deploy/terraform/bootstrap
·t·erraform a·pply -var "state_bucket=petbot-tfstate-423930895456"
```
Then re-run the Deploy workflow. Merging this PR keeps `master`'s bootstrap in sync for future applies.

https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF)_