### PR TITLE
Disable buildx provenance so Lambda accepts the image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,8 +76,13 @@ jobs:
           echo "ECR_REPO=$REPO" >> "$GITHUB_ENV"
           aws ecr get-login-password --region "${{ vars.AWS_REGION }}" \
             | docker login --username AWS --password-stdin "${REPO%%/*}"
+          # --provenance=false: buildx otherwise attaches a provenance
+          # attestation and pushes an OCI image *index*, which Lambda rejects
+          # ("image manifest ... media type ... is not supported"). Disabling it
+          # pushes a single image manifest Lambda accepts.
           docker buildx build \
             --platform linux/arm64 \
+            --provenance=false \
             -f ../Dockerfile.lambda \
             -t "$REPO:$IMAGE_TAG" \
             --push \


### PR DESCRIPTION
## Problem

After the `logs:DescribeLogGroups` fix (#45), the prod deploy got further — log group created — then failed at Lambda creation:

```
Error: creating Lambda Function (petbot-interactions): ...
InvalidParameterValueException: The image manifest, config or layer media type
for the source image …@sha256:… is not supported.
```

`docker buildx` (≥ 0.10) attaches a **provenance attestation** by default and therefore pushes an **OCI image index** (manifest list) even for a single platform. AWS Lambda's `CreateFunction` only accepts a single Docker/OCI **image manifest**, not an index — hence the rejection.

## Fix

Add `--provenance=false` to the `buildx build` step so it pushes a plain single-image manifest. One line (plus an explanatory comment). YAML validated.

## After merge

Merging triggers the Deploy workflow on `master` (push), which rebuilds with the fixed flag — that auto-run should complete the deploy. Otherwise re-run Deploy manually (master, blank `guild_id`). No bootstrap re-apply needed this time — this is purely the build step.

https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF)_