### PR TITLE
Install [interactions] extra so command registration can import the package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,9 @@ jobs:
           DISCORD_APP_ID: ${{ vars.DISCORD_APP_ID }}
           DISCORD_GUILD_ID: ${{ github.event.inputs.guild_id }}
         run: |
-          pip install -e .
+          # The [interactions] extra brings pynacl: importing the interactions
+          # package (via register) loads app -> handler -> verify, which needs it.
+          pip install -e ".[interactions]"
           TOKEN="$(aws ssm get-parameter \
             --name /petbot/interactions/discord_bot_token \
             --with-decryption --query Parameter.Value --output text)"


### PR DESCRIPTION
## Problem

The prod deploy now **succeeds through Terraform** — the Lambda + Function URL are live (`https://5s53yz2eyquhq7wkj5rghlynry0iectn.lambda-url.us-east-1.on.aws/`). Only the final **register** step failed:

```
ModuleNotFoundError: No module named 'nacl'
  …/petbot/frontends/interactions/verify.py line 12, in <module>
    from nacl.exceptions import BadSignatureError
```

The register step ran `pip install -e .` (base dependencies only). But `python -m petbot.frontends.interactions.register` imports the package `__init__`, which eagerly imports `app → handler → verify`, and `verify` needs **pynacl** — which lives in the `[interactions]` optional extra, not the base install.

## Fix

Install `".[interactions]"` in the register step. One-word change; matches the deps the Lambda image itself ships.

## After merge

Merging triggers Deploy on `master`. Terraform steps are no-ops now (infra exists); the rebuild runs and the register step will install pynacl and PUT the commands **global**. Then set Discord's Interactions Endpoint URL to the Function URL above.

(Future cleanup, not this PR: `register` doesn't actually need pynacl — the eager import in `interactions/__init__.py` is what drags it in. Could lazy-import to keep register dependency-light.)

https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyjvFLtA94cvpbLdkysiqF)_