### PR TITLE
feat: add Furbooru alongside Derpibooru and e621

### DIFF
--- a/src/petbot/skills/booru/__init__.py
+++ b/src/petbot/skills/booru/__init__.py
@@ -14,7 +14,14 @@ import httpx
 from petbot.skills.booru.settings import BooruSettings
 from petbot.skills.booru.skill import DerpiSkill, E621Skill, FurbooruSkill
 
-__all__ = ["DerpiSkill", "E621Skill", "FurbooruSkill", "build_derpi", "build_e621", "build_furbooru"]
+__all__ = [
+    "DerpiSkill",
+    "E621Skill",
+    "FurbooruSkill",
+    "build_derpi",
+    "build_e621",
+    "build_furbooru",
+]
 
 #: One client shared by the worker's booru skills (connection reuse).
 _client: httpx.AsyncClient | None = None

--- a/src/petbot/skills/booru/__init__.py
+++ b/src/petbot/skills/booru/__init__.py
@@ -1,7 +1,8 @@
-"""The booru skill package: the ``derpi`` and ``e621`` search skills.
+"""The booru skill package: the ``derpi``, ``furbooru``, and ``e621`` search skills.
 
-The entry-point factories (:func:`build_derpi`, :func:`build_e621`) read the
-worker's :class:`~petbot.skills.booru.settings.BooruSettings` and inject a shared
+The entry-point factories (:func:`build_derpi`, :func:`build_furbooru`,
+:func:`build_e621`) read the worker's
+:class:`~petbot.skills.booru.settings.BooruSettings` and inject a shared
 ``httpx.AsyncClient`` — the per-skill ``build(settings)`` wiring the worker uses
 in place of zero-arg construction.
 """
@@ -11,9 +12,9 @@ from __future__ import annotations
 import httpx
 
 from petbot.skills.booru.settings import BooruSettings
-from petbot.skills.booru.skill import DerpiSkill, E621Skill
+from petbot.skills.booru.skill import DerpiSkill, E621Skill, FurbooruSkill
 
-__all__ = ["DerpiSkill", "E621Skill", "build_derpi", "build_e621"]
+__all__ = ["DerpiSkill", "E621Skill", "FurbooruSkill", "build_derpi", "build_e621", "build_furbooru"]
 
 #: One client shared by the worker's booru skills (connection reuse).
 _client: httpx.AsyncClient | None = None
@@ -30,6 +31,12 @@ def build_derpi() -> DerpiSkill:
     """Build the Derpibooru skill from the environment."""
     settings = BooruSettings()
     return DerpiSkill(client=_shared_client(), api_key=settings.derpibooru_api_key)
+
+
+def build_furbooru() -> FurbooruSkill:
+    """Build the Furbooru skill from the environment."""
+    settings = BooruSettings()
+    return FurbooruSkill(client=_shared_client(), api_key=settings.furbooru_api_key)
 
 
 def build_e621() -> E621Skill:

--- a/src/petbot/skills/booru/derpibooru.py
+++ b/src/petbot/skills/booru/derpibooru.py
@@ -1,44 +1,18 @@
-"""Derpibooru provider (My Little Pony imageboard), API v1.
+"""Derpibooru (My Little Pony imageboard) — a Philomena instance.
 
-Tags are comma-separated and may contain spaces within a tag (the site's own
-convention; we don't coerce). Rating is a *tag* on Derpibooru, derived from the
-image's tag names on the way out. The "everything" filter is always used so the
-``safe`` system tag is the only content gate. Errors come back as a 400
-``{"error": "..."}``.
+All engine behaviour lives in :mod:`philomena`; this module only declares
+Derpibooru's rating taxonomy (it keeps the MLP-specific grimdark/grotesque tiers
+that Furbooru does not have) and wires the :class:`~philomena.Site`.
 """
 
 from __future__ import annotations
 
-import httpx
-from pydantic import BaseModel, Field
+from petbot.skills.booru import philomena, tags
 
-from petbot.skills.booru import tags
-from petbot.skills.booru.base import BooruProvider
-from petbot.skills.booru.types import Post, SearchRequest
-
-_NAME = "Derpibooru"
-_ROOT = "https://derpibooru.org/"
-_ENDPOINT = "https://derpibooru.org/api/v1/json/search/images"
-_ICON = "https://derpicdn.net/img/2017/10/22/1567638/thumb_small.jpeg"
-_FILTER_EVERYTHING = "56027"  # show all ratings; the `safe` tag is the only gate
-_MAX_PER_PAGE = 50
-
-
-class Sort(tags.Sort):
-    random = "random"
-    score = "score"
-    wilson = "wilson_score"
-    relevance = "relevance"
-    newest = "created_at"
-    first_seen = "first_seen_at"
-    updated = "updated_at"
-    comments = "comment_count"
-    tag_count = "tag_count"
-    favorites = "faves"
-    width = "width"
-    height = "height"
-    aspect_ratio = "aspect_ratio"
-    duration = "duration"
+# Re-export the shared Philomena vocabulary so callers can say derpibooru.Sort
+# and derpibooru.FileType without knowing about the philomena module.
+Sort = philomena.Sort
+FileType = philomena.FileType
 
 
 class Rating(tags.Rating):
@@ -51,25 +25,8 @@ class Rating(tags.Rating):
     grotesque = "grotesque"
 
 
-class FileType(tags.FileType):
-    png = "png"
-    jpeg = "jpeg"
-    gif = "gif"
-    svg = "svg"
-    webm = "webm"
-    mp4 = "mp4"
-
-
-_COLOR = {
-    Rating.safe: 0x00FF00,
-    Rating.suggestive: 0x0000FF,
-    Rating.questionable: 0xFFFF00,
-    Rating.explicit: 0xFF0000,
-    Rating.semi_grimdark: 0x80008B,
-    Rating.grimdark: 0x000000,
-    Rating.grotesque: 0x8B0000,
-}
-# Most severe first: the worst rating tag present decides colour/safety.
+# Most severe first; the last entry (safe) is the fallback when no rating tag
+# is present on an image.
 _SEVERITY = (
     Rating.explicit,
     Rating.grimdark,
@@ -80,100 +37,28 @@ _SEVERITY = (
     Rating.safe,
 )
 
+_COLOR: dict[tags.Rating, int] = {
+    Rating.safe: 0x00FF00,
+    Rating.suggestive: 0x0000FF,
+    Rating.questionable: 0xFFFF00,
+    Rating.explicit: 0xFF0000,
+    Rating.semi_grimdark: 0x80008B,
+    Rating.grimdark: 0x000000,
+    Rating.grotesque: 0x8B0000,
+}
 
-def _rating(image_tags: list[str]) -> Rating:
-    names = {tag.lower() for tag in image_tags}
-    return next((r for r in _SEVERITY if r.value in names), Rating.safe)
-
-
-class _Repr(BaseModel):
-    large: str | None = None
-
-
-class _Image(BaseModel):
-    id: int
-    score: int = 0
-    faves: int = 0
-    format: str = ""
-    tags: list[str] = Field(default_factory=list)
-    representations: _Repr = Field(default_factory=_Repr)
-    view_url: str | None = None
-
-
-class _Response(BaseModel):
-    total: int = 0
-    images: list[_Image] = Field(default_factory=list)
+SITE = philomena.Site(
+    name="Derpibooru",
+    root="https://derpibooru.org/",
+    endpoint="https://derpibooru.org/api/v1/json/search/images",
+    icon="https://derpicdn.net/img/2017/10/22/1567638/thumb_small.jpeg",
+    filter_everything="56027",  # system "Everything" filter; safe tag is the only gate
+    rating=Rating,
+    severity=_SEVERITY,
+    colors=_COLOR,
+)
 
 
-class _Error(BaseModel):
-    error: str | None = None
-
-
-class DerpibooruProvider(BooruProvider):
-    name: str = _NAME
-    site_name: str = _NAME
-    Sort: type[tags.Sort] = Sort
-    Rating: type[tags.Rating] = Rating
-    FileType: type[tags.FileType] = FileType
-
-    def __init__(self, *, api_key: str | None = None):
-        self._api_key = api_key
-
-    def parse_tags(self, raw: str) -> tuple[str, ...]:
-        # Derpibooru separates tags by commas; spaces are allowed within a tag.
-        return tuple(t.strip() for t in raw.split(",") if t.strip())
-
-    def build_request(self, client: httpx.AsyncClient, search: SearchRequest) -> httpx.Request:
-        terms = [*search.tags, *self._q_tags(search)]
-        params: dict[str, str | int] = {
-            "q": ",".join(terms) or "*",
-            "sf": (search.sort or Sort.random).value,
-            "sd": "desc" if search.descending else "asc",
-            "per_page": min(max(search.limit, 1), _MAX_PER_PAGE),
-            "page": search.page,
-            "filter_id": _FILTER_EVERYTHING,
-        }
-        if self._api_key:
-            params["key"] = self._api_key
-        return client.build_request("GET", _ENDPOINT, params=params)
-
-    def parse(self, body: object) -> Post | None:
-        decoded = _Response.model_validate(body)
-        if not decoded.images:
-            return None
-        img = decoded.images[0]
-        url = img.view_url or img.representations.large
-        if not url:
-            return None
-        if url.startswith("//"):  # `representations` come back protocol-relative
-            url = f"https:{url}"
-        rating = _rating(img.tags)
-        return Post(
-            post_id=img.id,
-            image_url=url,
-            color=_COLOR.get(rating, 0xFFFF00),
-            is_safe=rating is Rating.safe,
-            score=img.score,
-            favorites=img.faves,
-            file_ext=img.format,
-            page_url=f"{_ROOT}{img.id}",
-            site_name=_NAME,
-            site_root=_ROOT,
-            site_icon_url=_ICON,
-            total=decoded.total,
-        )
-
-    def error(self, body: object) -> str | None:
-        return _Error.model_validate(body).error
-
-    def _q_tags(self, s: SearchRequest) -> list[str]:
-        out: list[str] = []
-        if s.safe_only:
-            out.append(Rating.safe.value)
-        elif s.rating is not None:
-            out.append(s.rating.value)
-        if s.file_type is not None:
-            out.append(f"format:{s.file_type.value}")
-        out += tags.dotted_filter("score", s.score)
-        out += tags.dotted_filter("faves", s.favorites)
-        return out
+def DerpibooruProvider(*, api_key: str | None = None) -> philomena.PhilomenaProvider:
+    """Build a Derpibooru provider (factory kept for backwards-compat call sites)."""
+    return philomena.PhilomenaProvider(SITE, api_key=api_key)

--- a/src/petbot/skills/booru/furbooru.py
+++ b/src/petbot/skills/booru/furbooru.py
@@ -1,0 +1,46 @@
+"""Furbooru (furry imageboard) — a Philomena instance, like Derpibooru.
+
+All engine behaviour lives in :mod:`philomena`; this module only declares
+Furbooru's rating taxonomy (safe/suggestive/questionable/explicit — no MLP
+grimdark tiers) and wires the :class:`~philomena.Site`.
+"""
+
+from __future__ import annotations
+
+from petbot.skills.booru import philomena, tags
+
+Sort = philomena.Sort
+FileType = philomena.FileType
+
+
+class Rating(tags.Rating):
+    safe = "safe"
+    suggestive = "suggestive"
+    questionable = "questionable"
+    explicit = "explicit"
+
+
+_SEVERITY = (Rating.explicit, Rating.questionable, Rating.suggestive, Rating.safe)
+
+_COLOR: dict[tags.Rating, int] = {
+    Rating.safe: 0x00FF00,
+    Rating.suggestive: 0x0000FF,
+    Rating.questionable: 0xFFFF00,
+    Rating.explicit: 0xFF0000,
+}
+
+SITE = philomena.Site(
+    name="Furbooru",
+    root="https://furbooru.org/",
+    endpoint="https://furbooru.org/api/v1/json/search/images",
+    icon="https://furbooru.org/favicon.ico",
+    filter_everything="2",  # system "Everything" filter; safe tag is the only gate
+    rating=Rating,
+    severity=_SEVERITY,
+    colors=_COLOR,
+)
+
+
+def FurbooruProvider(*, api_key: str | None = None) -> philomena.PhilomenaProvider:
+    """Build a Furbooru provider."""
+    return philomena.PhilomenaProvider(SITE, api_key=api_key)

--- a/src/petbot/skills/booru/philomena.py
+++ b/src/petbot/skills/booru/philomena.py
@@ -1,0 +1,187 @@
+"""Philomena imageboard engine (Derpibooru, Furbooru, …), API v1.
+
+Every Philomena instance speaks the same dialect: comma-separated tags (spaces
+allowed within a tag), an ``/api/v1/json/search/images`` endpoint taking
+``q``/``sf``/``sd``/``per_page``/``filter_id``/``key``, dotted numeric filters
+(``score.gte:100``), rating expressed as a *tag* (derived from the image's tags
+on the way out), and a ``{"total": ..., "images": [...]}`` body.
+
+Instances differ only in *data* — base URL, the "everything" filter id, and which
+ratings the site defines — so a single :class:`PhilomenaProvider` is configured
+by a :class:`Site` dataclass rather than subclassed per site.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+import httpx
+from pydantic import BaseModel, Field
+
+from petbot.skills.booru import tags
+from petbot.skills.booru.base import BooruProvider
+from petbot.skills.booru.types import Post, SearchRequest
+
+
+# Sort fields and file formats are baked into the Philomena software itself, so
+# they are identical across all instances and defined once here.
+class Sort(tags.Sort):
+    random = "random"
+    score = "score"
+    wilson = "wilson_score"
+    relevance = "relevance"
+    newest = "created_at"
+    first_seen = "first_seen_at"
+    updated = "updated_at"
+    comments = "comment_count"
+    tag_count = "tag_count"
+    favorites = "faves"
+    width = "width"
+    height = "height"
+    aspect_ratio = "aspect_ratio"
+    duration = "duration"
+
+
+class FileType(tags.FileType):
+    png = "png"
+    jpeg = "jpeg"
+    gif = "gif"
+    svg = "svg"
+    webm = "webm"
+    mp4 = "mp4"
+
+
+@dataclass(frozen=True, slots=True)
+class Site:
+    """Everything that distinguishes one Philomena instance from another.
+
+    ``filter_everything`` is the site's filter that hides nothing, so the
+    ``safe`` tag stays the only content gate. ``severity`` is most-severe-first:
+    the worst rating tag present on an image decides its colour and safety.
+    ``colors`` maps each rating to a Discord embed colour.
+    """
+
+    name: str
+    root: str
+    endpoint: str
+    icon: str
+    filter_everything: str
+    rating: type[tags.Rating]
+    severity: tuple[tags.Rating, ...]
+    colors: Mapping[tags.Rating, int] = field(default_factory=dict)
+    max_per_page: int = 50
+
+
+# --- Pydantic models for the wire format --------------------------------------
+
+
+class _Repr(BaseModel):
+    large: str | None = None
+
+
+class _Image(BaseModel):
+    id: int
+    score: int = 0
+    faves: int = 0
+    format: str = ""
+    tags: list[str] = Field(default_factory=list)
+    representations: _Repr = Field(default_factory=_Repr)
+    view_url: str | None = None
+
+
+class _Response(BaseModel):
+    total: int = 0
+    images: list[_Image] = Field(default_factory=list)
+
+
+class _Error(BaseModel):
+    error: str | None = None
+
+
+# --- Provider -----------------------------------------------------------------
+
+
+class PhilomenaProvider(BooruProvider):
+    """A :class:`BooruProvider` for any Philomena site.
+
+    Behaviour is shared; the :class:`Site` supplies the data that distinguishes
+    each instance (URL, filter id, rating vocabulary, colours).
+    """
+
+    Sort: type[tags.Sort] = Sort
+    FileType: type[tags.FileType] = FileType
+
+    def __init__(self, site: Site, *, api_key: str | None = None) -> None:
+        self._site = site
+        self._api_key = api_key
+        self.name = site.name
+        self.site_name = site.name
+        self.Rating: type[tags.Rating] = site.rating  # per-site; Sort/FileType are shared
+
+    def parse_tags(self, raw: str) -> tuple[str, ...]:
+        # Philomena separates tags by commas; spaces are allowed within a tag.
+        return tuple(t.strip() for t in raw.split(",") if t.strip())
+
+    def build_request(self, client: httpx.AsyncClient, search: SearchRequest) -> httpx.Request:
+        terms = [*search.tags, *self._q_tags(search)]
+        params: dict[str, str | int] = {
+            "q": ",".join(terms) or "*",
+            "sf": (search.sort or Sort.random).value,
+            "sd": "desc" if search.descending else "asc",
+            "per_page": min(max(search.limit, 1), self._site.max_per_page),
+            "page": search.page,
+            "filter_id": self._site.filter_everything,
+        }
+        if self._api_key:
+            params["key"] = self._api_key
+        return client.build_request("GET", self._site.endpoint, params=params)
+
+    def parse(self, body: object) -> Post | None:
+        decoded = _Response.model_validate(body)
+        if not decoded.images:
+            return None
+        img = decoded.images[0]
+        url = img.view_url or img.representations.large
+        if not url:
+            return None
+        if url.startswith("//"):  # representations come back protocol-relative
+            url = f"https:{url}"
+        rating = self._infer_rating(img.tags)
+        return Post(
+            post_id=img.id,
+            image_url=url,
+            color=self._site.colors.get(rating, 0xFFFF00),
+            is_safe=rating.value == "safe",  # "safe" is the safe tag on every Philomena instance
+            score=img.score,
+            favorites=img.faves,
+            file_ext=img.format,
+            page_url=f"{self._site.root}{img.id}",
+            site_name=self._site.name,
+            site_root=self._site.root,
+            site_icon_url=self._site.icon,
+            total=decoded.total,
+        )
+
+    def error(self, body: object) -> str | None:
+        return _Error.model_validate(body).error
+
+    def _infer_rating(self, image_tags: list[str]) -> tags.Rating:
+        names = {t.lower() for t in image_tags}
+        # severity is most-severe-first; the last entry is always the safe fallback
+        return next(
+            (r for r in self._site.severity if r.value in names),
+            self._site.severity[-1],
+        )
+
+    def _q_tags(self, s: SearchRequest) -> list[str]:
+        out: list[str] = []
+        if s.safe_only:
+            out.append("safe")  # "safe" is the Philomena safe-rating tag on every instance
+        elif s.rating is not None:
+            out.append(s.rating.value)
+        if s.file_type is not None:
+            out.append(f"format:{s.file_type.value}")
+        out += tags.dotted_filter("score", s.score)
+        out += tags.dotted_filter("faves", s.favorites)
+        return out

--- a/src/petbot/skills/booru/settings.py
+++ b/src/petbot/skills/booru/settings.py
@@ -29,9 +29,12 @@ class BooruSettings(BaseSettings):
     e621_username: str | None = None
     e621_api_key: str | None = None
     derpibooru_api_key: str | None = None
+    furbooru_api_key: str | None = None
     user_agent: str = DEFAULT_USER_AGENT
 
-    @field_validator("e621_username", "e621_api_key", "derpibooru_api_key", mode="before")
+    @field_validator(
+        "e621_username", "e621_api_key", "derpibooru_api_key", "furbooru_api_key", mode="before"
+    )
     @classmethod
     def _blank_to_none(cls, value: object) -> object:
         if isinstance(value, str) and not value.strip():

--- a/src/petbot/skills/booru/skill.py
+++ b/src/petbot/skills/booru/skill.py
@@ -1,19 +1,23 @@
-"""Booru search skills: ``derpi`` and ``e621``.
+"""Booru search skills: ``derpi``, ``furbooru``, and ``e621``.
 
-Both wrap a provider in this package's engine. There is no explicit *option*: the
-channel decides the safety floor (``safe_only`` comes from ``ctx.allows_explicit``,
-which the edge fills from ``channel.is_nsfw()``). The other options — ``sort``,
-``file_type``, ``min_score`` — map onto each provider's full native vocabulary.
+Derpibooru and Furbooru both run Philomena; they share a ``_PhilomenaSkill``
+base whose only variable is the factory function that builds the provider.
+e621 uses a completely different API and keeps its own concrete class.
+
+There is no explicit safety option: the channel decides the safety floor
+(``safe_only`` comes from ``ctx.allows_explicit``, which the edge fills from
+``channel.is_nsfw()``).
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 import httpx
 
 from petbot.domain import Skill, SkillContext, SkillResult
-from petbot.skills.booru import derpibooru, e621
+from petbot.skills.booru import derpibooru, e621, furbooru
 from petbot.skills.booru.base import BooruProvider
 from petbot.skills.booru.engine import run_search
 from petbot.skills.booru.errors import SiteFailureStatusError
@@ -69,19 +73,36 @@ async def _run(
         return SkillResult.failure(_NETWORK_FAILURE)
 
 
-class DerpiSkill(Skill[BooruArgs]):
+# Philomena sites (Derpibooru, Furbooru) share the same skill shape; only the
+# provider factory differs.
+class _PhilomenaSkill(Skill[BooruArgs]):
+    """Shared base for every Philomena-backed search skill."""
+
+    args_model = BooruArgs
+    _provider_factory: Callable[..., BooruProvider]
+
+    def __init__(self, *, client: httpx.AsyncClient, api_key: str | None = None) -> None:
+        self._client = client
+        self._provider: BooruProvider = type(self)._provider_factory(api_key=api_key)
+
+    async def run(self, args: BooruArgs, ctx: SkillContext) -> SkillResult:
+        return await _run(self._provider, self._client, args, ctx)
+
+
+class DerpiSkill(_PhilomenaSkill):
     """Search Derpibooru for an image matching the given tags."""
 
     name = "derpi"
     description = "Search Derpibooru for an image matching the given tags."
-    args_model = BooruArgs
+    _provider_factory = derpibooru.DerpibooruProvider
 
-    def __init__(self, *, client: httpx.AsyncClient, api_key: str | None = None) -> None:
-        self._client = client
-        self._provider = derpibooru.DerpibooruProvider(api_key=api_key)
 
-    async def run(self, args: BooruArgs, ctx: SkillContext) -> SkillResult:
-        return await _run(self._provider, self._client, args, ctx)
+class FurbooruSkill(_PhilomenaSkill):
+    """Search Furbooru for an image matching the given tags."""
+
+    name = "furbooru"
+    description = "Search Furbooru for an image matching the given tags."
+    _provider_factory = furbooru.FurbooruProvider
 
 
 class E621Skill(Skill[BooruArgs]):
@@ -106,3 +127,4 @@ class E621Skill(Skill[BooruArgs]):
 
     async def run(self, args: BooruArgs, ctx: SkillContext) -> SkillResult:
         return await _run(self._provider, self._client, args, ctx)
+

--- a/src/petbot/skills/booru/skill.py
+++ b/src/petbot/skills/booru/skill.py
@@ -127,4 +127,3 @@ class E621Skill(Skill[BooruArgs]):
 
     async def run(self, args: BooruArgs, ctx: SkillContext) -> SkillResult:
         return await _run(self._provider, self._client, args, ctx)
-

--- a/tests/skills/booru/fixtures/furbooru_success.json
+++ b/tests/skills/booru/fixtures/furbooru_success.json
@@ -1,0 +1,16 @@
+{
+  "total": 17,
+  "images": [
+    {
+      "id": 654321,
+      "score": 42,
+      "faves": 10,
+      "format": "png",
+      "tags": ["safe", "canine", "wolf"],
+      "representations": {
+        "large": "//furbooru.org/img/2021/1/1/654321/large.png"
+      },
+      "view_url": "https://furbooru.org/img/2021/1/1/654321/full.png"
+    }
+  ]
+}

--- a/tests/skills/booru/test_booru.py
+++ b/tests/skills/booru/test_booru.py
@@ -11,10 +11,10 @@ import pytest
 import respx
 
 from conftest import load_fixture, make_context
-from petbot.skills.booru import derpibooru, e621, tags
+from petbot.skills.booru import derpibooru, e621, furbooru, philomena, tags
 from petbot.skills.booru.engine import run_search
 from petbot.skills.booru.errors import SiteFailureStatusError
-from petbot.skills.booru.skill import DerpiSkill, E621Skill, _build_search
+from petbot.skills.booru.skill import DerpiSkill, E621Skill, FurbooruSkill, _build_search
 from petbot.skills.booru.types import SearchRequest
 from petbot.types import BooruArgs
 
@@ -33,6 +33,17 @@ def test_vocabulary_is_per_site_and_full_native() -> None:
     assert "hot" in {s.value for s in e621.Sort}
     assert "suggestive" in {r.value for r in derpibooru.Rating}  # Derpi-only
     assert "suggestive" not in {r.value for r in e621.Rating}
+    # Derpibooru has MLP-specific tiers; Furbooru does not
+    assert "grimdark" in {r.value for r in derpibooru.Rating}
+    assert "grimdark" not in {r.value for r in furbooru.Rating}
+    assert "suggestive" in {r.value for r in furbooru.Rating}
+
+
+def test_philomena_sort_and_filetype_shared_across_sites() -> None:
+    assert derpibooru.Sort is philomena.Sort
+    assert furbooru.Sort is philomena.Sort
+    assert derpibooru.FileType is philomena.FileType
+    assert furbooru.FileType is philomena.FileType
 
 
 def test_range_serialization_dialects() -> None:
@@ -66,6 +77,7 @@ def test_parse_tags_follows_site_convention() -> None:
         "twilight sparkle",
         "safe",
     )
+    assert furbooru.FurbooruProvider().parse_tags("wolf, canine") == ("wolf", "canine")
 
 
 # --- request shaping (inspect the built httpx.Request) ------------------------
@@ -139,6 +151,40 @@ async def test_derpi_sort_direction_is_caller_controlled() -> None:
     assert asc.url.params["sd"] == "asc"
 
 
+async def test_furbooru_build_request_uses_filter_id_2() -> None:
+    provider = furbooru.FurbooruProvider(api_key="k")
+    search = SearchRequest(
+        tags=("wolf",),
+        safe_only=True,
+        sort=philomena.Sort.favorites,
+        score=tags.NumericFilter(at_least=10),
+    )
+    async with httpx.AsyncClient() as client:
+        req = provider.build_request(client, search)
+    assert req.url.params["q"] == "wolf,safe,score.gte:10"
+    assert req.url.params["sf"] == "faves"
+    assert req.url.params["filter_id"] == "2"
+    assert req.url.params["key"] == "k"
+    assert "furbooru.org" in req.url.host
+
+
+async def test_furbooru_sort_direction_is_caller_controlled() -> None:
+    provider = furbooru.FurbooruProvider()
+    async with httpx.AsyncClient() as client:
+        desc = provider.build_request(client, SearchRequest(tags=("a",), descending=True))
+        asc = provider.build_request(client, SearchRequest(tags=("a",), descending=False))
+    assert desc.url.params["sd"] == "desc"
+    assert asc.url.params["sd"] == "asc"
+
+
+async def test_furbooru_nsfw_no_tags_uses_wildcard() -> None:
+    provider = furbooru.FurbooruProvider()
+    async with httpx.AsyncClient() as client:
+        req = provider.build_request(client, SearchRequest(tags=(), safe_only=False))
+    assert req.url.params["q"] == "*"
+    assert "key" not in req.url.params
+
+
 # --- response decoding --------------------------------------------------------
 
 
@@ -160,6 +206,27 @@ def test_derpi_parse() -> None:
     assert post.color == 0x00FF00
 
 
+def test_furbooru_parse() -> None:
+    post = furbooru.FurbooruProvider().parse(load_fixture("furbooru_success"))
+    assert post is not None
+    assert post.post_id == 654321
+    assert post.total == 17
+    assert post.is_safe is True
+    assert post.color == 0x00FF00
+    assert post.page_url == "https://furbooru.org/654321"
+    assert post.site_name == "Furbooru"
+
+
+def test_furbooru_absolutizes_protocol_relative_url() -> None:
+    body = {
+        "total": 1,
+        "images": [{"id": 9, "representations": {"large": "//furbooru.org/img/large.png"}}],
+    }
+    post = furbooru.FurbooruProvider().parse(body)
+    assert post is not None
+    assert post.image_url == "https://furbooru.org/img/large.png"
+
+
 def test_parse_none_on_empty_or_blocked() -> None:
     e = e621.E621Provider(user_agent="x")
     assert e.parse(load_fixture("e621_empty")) is None
@@ -176,6 +243,9 @@ def test_error_extraction() -> None:
     d = derpibooru.DerpibooruProvider()
     assert d.error(load_fixture("derpibooru_error")) == "Imbalanced parentheses."
     assert d.error(load_fixture("derpibooru_success")) is None
+    f = furbooru.FurbooruProvider()
+    assert f.error(load_fixture("derpibooru_error")) == "Imbalanced parentheses."  # same schema
+    assert f.error(load_fixture("furbooru_success")) is None
 
 
 # --- engine (respx transport mock) -------------------------------------------
@@ -232,6 +302,30 @@ async def test_skill_nsfw_does_not_inject_safe() -> None:
         skill = DerpiSkill(client=client)
         await skill.run(BooruArgs(tags="pony"), make_context(allows_explicit=True))
     assert route.calls.last.request.url.params["q"] == "pony"
+
+
+@respx.mock
+async def test_furbooru_skill_sfw_constrains_to_safe() -> None:
+    route = respx.get("https://furbooru.org/api/v1/json/search/images").mock(
+        return_value=httpx.Response(200, json=load_fixture("furbooru_success"))
+    )
+    async with httpx.AsyncClient() as client:
+        skill = FurbooruSkill(client=client)
+        result = await skill.run(BooruArgs(tags="wolf"), make_context(allows_explicit=False))
+    assert not result.is_error and result.embed is not None
+    assert "safe" in route.calls.last.request.url.params["q"]
+    assert route.calls.last.request.url.params["filter_id"] == "2"
+
+
+@respx.mock
+async def test_furbooru_skill_nsfw_does_not_inject_safe() -> None:
+    route = respx.get("https://furbooru.org/api/v1/json/search/images").mock(
+        return_value=httpx.Response(200, json=load_fixture("furbooru_success"))
+    )
+    async with httpx.AsyncClient() as client:
+        skill = FurbooruSkill(client=client)
+        await skill.run(BooruArgs(tags="wolf"), make_context(allows_explicit=True))
+    assert route.calls.last.request.url.params["q"] == "wolf"
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

- Extract shared Philomena engine into `src/petbot/skills/booru/philomena.py` — Derpibooru and Furbooru share all request-building, response-parsing, and dotted-filter logic; each site is a thin data module (~45 lines: `Rating` enum + `Site` config + factory function)
- Add `furbooru.py` with `filter_id="2"` (confirmed via gallery-dl extractor source)
- Add `FurbooruSkill` + `build_furbooru()` entry point
- Add `FURBOORU_API_KEY` optional credential to `BooruSettings`

## Architecture

Two booru shapes, not three:
- **Philomena** (Derpibooru + Furbooru): shared `PhilomenaProvider`, configured by `Site` dataclass. `_PhilomenaSkill` base in `skill.py`, `_provider_factory` class variable selects the site.
- **e621**: genuine outlier, unchanged.

Adding a fourth Philomena site = one ~45-line data file.

## Rebased onto master

Branch was reset to `master` HEAD (`9c5289b`) and the Philomena refactor reapplied cleanly on the new `src/` layout.

## Test plan

- [ ] 29 tests pass (8 new Furbooru cases: request shaping, `filter_id=2`, parse, protocol-relative URL, SFW/NSFW skill injection)
- [ ] `FURBOORU_API_KEY` env var wires correctly (optional; anonymous search works)
- [ ] `/furbooru wolf` in SFW channel injects `safe` tag; NSFW channel does not