### PR TITLE
Default booru searches to random ordering

### DIFF
--- a/petbot/core/skills/booru_skill.py
+++ b/petbot/core/skills/booru_skill.py
@@ -63,10 +63,22 @@ def _schema(
     }
 
 
+def _default_sort(provider: BooruProvider) -> Sort | None:
+    """The ordering used when the caller names none: ``random``, so that a bare
+    search (e.g. ``/e621 tag:hyena``) returns a *different* image each time rather
+    than always the newest match. Both providers expose a ``random`` order; the
+    guard keeps this safe if a future provider's vocabulary ever lacks one.
+    """
+    try:
+        return provider.Sort("random")
+    except ValueError:
+        return None
+
+
 def _build_search(
     provider: BooruProvider, args: Mapping[str, Any], ctx: SkillContext
 ) -> SearchRequest:
-    sort = provider.Sort(str(args["sort"])) if args.get("sort") else None
+    sort = provider.Sort(str(args["sort"])) if args.get("sort") else _default_sort(provider)
     file_type = provider.FileType(str(args["file_type"])) if args.get("file_type") else None
     min_score = args.get("min_score")
     score = NumericFilter(at_least=int(min_score)) if min_score is not None else None

--- a/tests/test_booru_parse.py
+++ b/tests/test_booru_parse.py
@@ -15,7 +15,7 @@ from petbot.core.capabilities.boorus import derpibooru, e621, tags
 from petbot.core.capabilities.boorus.engine import run_search
 from petbot.core.capabilities.boorus.errors import SiteFailureStatusError
 from petbot.core.capabilities.boorus.types import SearchRequest
-from petbot.core.skills.booru_skill import DerpiSkill, E621Skill
+from petbot.core.skills.booru_skill import DerpiSkill, E621Skill, _build_search
 
 # --- abstract vocabulary ------------------------------------------------------
 
@@ -94,6 +94,24 @@ async def test_e621_build_request_serializes_system_tags() -> None:
     assert req.url.params["limit"] == "1"
     assert req.headers["user-agent"] == "PetBot/2.0 (test)"
     assert req.headers["authorization"].startswith("Basic ")
+
+
+def test_default_sort_is_random_on_both_providers() -> None:
+    # A bare search (no `sort` arg) must default to each site's random order so
+    # repeated calls vary instead of always returning the newest match.
+    ctx = make_context()
+    e621_search = _build_search(e621.E621Provider(user_agent="x"), {"tags": "hyena"}, ctx)
+    derpi_search = _build_search(derpibooru.DerpibooruProvider(), {"tags": "pinkie pie"}, ctx)
+    assert e621_search.sort is e621.Sort.random
+    assert derpi_search.sort is derpibooru.Sort.random
+
+
+async def test_e621_bare_search_requests_random_order() -> None:
+    # End-to-end shaping: the default flows through into the `order:random` tag.
+    search = _build_search(e621.E621Provider(user_agent="x"), {"tags": "hyena"}, make_context())
+    async with httpx.AsyncClient() as client:
+        req = e621.E621Provider(user_agent="x").build_request(client, search)
+    assert "order:random" in req.url.params["tags"].split()
 
 
 async def test_e621_nsfw_omits_rating_and_no_auth_without_creds() -> None:


### PR DESCRIPTION
## Audit findings

`/e621 tag:hyena` (and any bare search) returned the **same image** every call.

**Root cause.** In `_build_search` (`booru_skill.py`), a missing `sort` arg produced `sort=None`. e621's `_system_tags` only emits an `order:` tag when sort is set, so e621 fell back to its API default (`order:id`, newest first). With `limit=1` + `parse()` taking `posts[0]`, that's always the newest matching post.

**The real issue was divergence.** Derpibooru already defaulted to random inline (`"sf": (search.sort or Sort.random).value`), so the two providers behaved differently for an identical bare search.

## Fix

Centralize the default in `_build_search`: when the caller names no sort, use the provider's `random` order via a small `_default_sort` helper (guarded so a future provider whose vocabulary lacks `random` degrades to `None` rather than crashing). Both skills now return a varied image per call.

Derpibooru's inline `or Sort.random` is kept as a defensive fallback for `SearchRequest`s constructed directly (e.g. in tests), where the skill layer isn't in the path.

## Tests

- `test_default_sort_is_random_on_both_providers` — both providers default to `random`.
- `test_e621_bare_search_requests_random_order` — the default flows through to the `order:random` wire tag.

Full suite: 105 passed, 2 skipped.

https://claude.ai/code/session_014mkLL9ePTLfmgtLGPUA94o

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkLL9ePTLfmgtLGPUA94o)_