### PR TITLE
feat(deploy): retarget AWS stack to the 2.1 edge + core-worker topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Sync (workspace members + all extras)
+      - name: Sync (all extras)
         # --locked fails if uv.lock is stale; uv itself fetches/pins Python 3.12.
-        run: uv sync --locked --all-extras --all-packages --python 3.12
+        # One package, so --all-extras installs everything (edge, worker, lambda, dev).
+        run: uv sync --locked --all-extras --python 3.12
 
       - name: Ruff (lint + format check)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: Deploy
 
-# Build + push the core worker Lambda image (arm64) and the edge container image
-# (amd64), then terraform apply — entirely from CI via GitHub OIDC (no static AWS
-# keys). See deploy/terraform/README.md. The one-time trust bootstrap (OIDC
-# provider + deploy role + state bucket + SSM secrets) is run once from AWS
-# CloudShell.
+# Build + push the core worker image (arm64) and the edge image (amd64) to ECR,
+# then terraform apply — entirely from CI via GitHub OIDC (no static AWS keys).
+# The Lightsail edge pulls its image from ECR (private-registry access). See
+# deploy/terraform/README.md. The one-time trust bootstrap (OIDC provider +
+# deploy role + state bucket + SSM secrets) is run once from AWS CloudShell.
 on:
   workflow_dispatch:
   push:
@@ -21,11 +21,18 @@ concurrency:
 
 env:
   TF_DIR: deploy/terraform
+  # Non-secret deploy config, supplied as GitHub Actions Variables and read by
+  # Terraform as TF_VAR_* (secret *values* stay in SSM, referenced by name).
+  TF_VAR_aws_region: ${{ vars.AWS_REGION }}
+  TF_VAR_chat_llm_kind: ${{ vars.CHAT_LLM_KIND }}
+  TF_VAR_chat_llm_model: ${{ vars.CHAT_LLM_MODEL }}
+  TF_VAR_chat_llm_api_key_ssm_parameter: ${{ vars.CHAT_LLM_API_KEY_SSM_PARAMETER }}
 
 jobs:
   deploy:
     # arm64 runner matches the worker Lambda's Graviton architecture, so that
-    # image builds natively; the edge image is built for amd64 via buildx.
+    # image builds natively; the smaller edge image cross-builds for amd64 via
+    # QEMU (cheaper to emulate than the heavy worker image).
     runs-on: ubuntu-24.04-arm
     # Optional manual-approval gate; configure required reviewers on the
     # `production` GitHub Environment to require sign-off before a deploy runs.
@@ -39,7 +46,7 @@ jobs:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # buildx for the gha layer cache and the amd64 edge build on an arm64 runner.
+      # buildx for the gha layer cache; QEMU for the amd64 edge build on arm.
       - uses: docker/setup-buildx-action@v3
       - uses: docker/setup-qemu-action@v3
 
@@ -60,25 +67,24 @@ jobs:
             -backend-config="encrypt=true" \
             -backend-config="use_lockfile=true"
 
-      # The worker function is pinned to the image digest and the edge needs its
-      # Lightsail service to exist before an image can be pushed, so create just
-      # those two containers first (idempotent on re-runs).
-      - name: Ensure ECR repo + edge container service exist
+      # The function is pinned to its image digest, and the edge service must grant
+      # ECR-pull access before the deployment is created — so stand up the two ECR
+      # repos, the Lightsail service, and the edge repo policy first (idempotent).
+      - name: Ensure registries + edge service exist
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform apply -auto-approve \
             -target=aws_ecr_repository.this \
-            -target=aws_lightsail_container_service.edge
-          # Names derive from var.name_prefix; read them back rather than hardcode.
-          echo "EDGE_SVC=$(terraform output -raw edge_container_service_name)" >> "$GITHUB_ENV"
+            -target=aws_ecr_repository.edge \
+            -target=aws_lightsail_container_service.edge \
+            -target=aws_ecr_repository_policy.edge
+          echo "ECR_REPO=$(terraform output -raw ecr_repository_url)" >> "$GITHUB_ENV"
+          echo "EDGE_ECR_REPO=$(terraform output -raw edge_ecr_repository_url)" >> "$GITHUB_ENV"
 
       - name: ECR login
-        working-directory: ${{ env.TF_DIR }}
         run: |
-          REPO=$(terraform output -raw ecr_repository_url)
-          echo "ECR_REPO=$REPO" >> "$GITHUB_ENV"
           aws ecr get-login-password --region "${{ vars.AWS_REGION }}" \
-            | docker login --username AWS --password-stdin "${REPO%%/*}"
+            | docker login --username AWS --password-stdin "${ECR_REPO%%/*}"
 
       - name: Build & push core worker image (arm64)
         uses: docker/build-push-action@v6
@@ -91,44 +97,27 @@ jobs:
           # provenance=false: buildx otherwise pushes an OCI image *index*, which
           # Lambda rejects; this pushes a single image manifest Lambda accepts.
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
 
-      # The edge image goes to Lightsail's own registry (not ECR). Build amd64
-      # locally, then `lightsail push-container-image` returns a ref like
-      # ":petbot-edge.edge.N" that the deployment is pinned to.
-      - name: Build edge image (amd64)
+      - name: Build & push edge image (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/Dockerfile.edge
           platforms: linux/amd64
-          tags: petbot-edge:${{ env.IMAGE_TAG }}
-          load: true
+          tags: ${{ env.EDGE_ECR_REPO }}:${{ env.IMAGE_TAG }}
+          push: true
           provenance: false
-
-      - name: Push edge image to Lightsail
-        run: |
-          OUT=$(aws lightsail push-container-image \
-            --region "${{ vars.AWS_REGION }}" \
-            --service-name "$EDGE_SVC" \
-            --label edge \
-            --image "petbot-edge:${IMAGE_TAG}")
-          echo "$OUT"
-          # The CLI prints: Refer to this image as ":<service>.edge.N" ...
-          REF=$(echo "$OUT" | grep -oE "\":${EDGE_SVC}\.edge\.[0-9]+\"" | tr -d '"' | head -n1)
-          if [ -z "$REF" ]; then
-            echo "::error::could not parse the pushed image ref from lightsail output"
-            exit 1
-          fi
-          echo "EDGE_IMAGE=$REF" >> "$GITHUB_ENV"
+          cache-from: type=gha,scope=edge
+          cache-to: type=gha,mode=max,scope=edge
 
       - name: Terraform apply
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform apply -auto-approve \
             -var "image_tag=$IMAGE_TAG" \
-            -var "edge_image=$EDGE_IMAGE"
+            -var "edge_image_tag=$IMAGE_TAG"
 
       - name: Show outputs
         working-directory: ${{ env.TF_DIR }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,12 @@
 name: Deploy
 
-# Build + push the arm64 Lambda image, terraform apply, and register the slash
-# commands — entirely from CI via GitHub OIDC (no static AWS keys). See issue #42
-# and deploy/terraform/README.md. The one-time trust bootstrap (OIDC provider +
-# deploy role + state bucket + SSM secrets) is run once from AWS CloudShell.
+# Build + push the core worker Lambda image (arm64) and the edge container image
+# (amd64), then terraform apply — entirely from CI via GitHub OIDC (no static AWS
+# keys). See deploy/terraform/README.md. The one-time trust bootstrap (OIDC
+# provider + deploy role + state bucket + SSM secrets) is run once from AWS
+# CloudShell.
 on:
-  # Manual run: lets you target a single guild for instant, guild-scoped command
-  # registration (the dev-guild rollout) before going global.
   workflow_dispatch:
-    inputs:
-      guild_id:
-        description: "Guild ID for instant guild-scoped command registration (blank = global)."
-        required: false
-        default: ""
   push:
     branches: [master]
 
@@ -30,8 +24,8 @@ env:
 
 jobs:
   deploy:
-    # arm64 runner matches the Lambda's Graviton architecture, so the image
-    # builds natively without QEMU emulation.
+    # arm64 runner matches the worker Lambda's Graviton architecture, so that
+    # image builds natively; the edge image is built for amd64 via buildx.
     runs-on: ubuntu-24.04-arm
     # Optional manual-approval gate; configure required reviewers on the
     # `production` GitHub Environment to require sign-off before a deploy runs.
@@ -45,9 +39,9 @@ jobs:
           role-to-assume: ${{ vars.DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # buildx for the build-push step's gha layer cache; no QEMU needed on an
-      # arm64 runner building an arm64 image.
+      # buildx for the gha layer cache and the amd64 edge build on an arm64 runner.
       - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v3
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -61,16 +55,22 @@ jobs:
         run: |
           terraform init \
             -backend-config="bucket=${{ vars.TF_STATE_BUCKET }}" \
-            -backend-config="key=interactions/terraform.tfstate" \
+            -backend-config="key=petbot/terraform.tfstate" \
             -backend-config="region=${{ vars.AWS_REGION }}" \
             -backend-config="encrypt=true" \
             -backend-config="use_lockfile=true"
 
-      # The function is pinned to the image digest, so the image must exist before
-      # the full apply. Create just the ECR repo first (idempotent on re-runs).
-      - name: Ensure ECR repository exists
+      # The worker function is pinned to the image digest and the edge needs its
+      # Lightsail service to exist before an image can be pushed, so create just
+      # those two containers first (idempotent on re-runs).
+      - name: Ensure ECR repo + edge container service exist
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -target=aws_ecr_repository.this
+        run: |
+          terraform apply -auto-approve \
+            -target=aws_ecr_repository.this \
+            -target=aws_lightsail_container_service.edge
+          # Names derive from var.name_prefix; read them back rather than hardcode.
+          echo "EDGE_SVC=$(terraform output -raw edge_container_service_name)" >> "$GITHUB_ENV"
 
       - name: ECR login
         working-directory: ${{ env.TF_DIR }}
@@ -80,49 +80,58 @@ jobs:
           aws ecr get-login-password --region "${{ vars.AWS_REGION }}" \
             | docker login --username AWS --password-stdin "${REPO%%/*}"
 
-      - name: Build & push arm64 image
+      - name: Build & push core worker image (arm64)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/Dockerfile.lambda
+          platforms: linux/arm64
           tags: ${{ env.ECR_REPO }}:${{ env.IMAGE_TAG }}
           push: true
-          # provenance=false: buildx otherwise attaches a provenance attestation
-          # and pushes an OCI image *index*, which Lambda rejects ("image
-          # manifest ... media type ... is not supported"). This pushes a single
-          # image manifest Lambda accepts.
+          # provenance=false: buildx otherwise pushes an OCI image *index*, which
+          # Lambda rejects; this pushes a single image manifest Lambda accepts.
           provenance: false
-          # Reuse layers across runs: when pyproject/deps are unchanged the
-          # install layer is restored instead of rebuilt.
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The edge image goes to Lightsail's own registry (not ECR). Build amd64
+      # locally, then `lightsail push-container-image` returns a ref like
+      # ":petbot-edge.edge.N" that the deployment is pinned to.
+      - name: Build edge image (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile.edge
+          platforms: linux/amd64
+          tags: petbot-edge:${{ env.IMAGE_TAG }}
+          load: true
+          provenance: false
+
+      - name: Push edge image to Lightsail
+        run: |
+          OUT=$(aws lightsail push-container-image \
+            --region "${{ vars.AWS_REGION }}" \
+            --service-name "$EDGE_SVC" \
+            --label edge \
+            --image "petbot-edge:${IMAGE_TAG}")
+          echo "$OUT"
+          # The CLI prints: Refer to this image as ":<service>.edge.N" ...
+          REF=$(echo "$OUT" | grep -oE "\":${EDGE_SVC}\.edge\.[0-9]+\"" | tr -d '"' | head -n1)
+          if [ -z "$REF" ]; then
+            echo "::error::could not parse the pushed image ref from lightsail output"
+            exit 1
+          fi
+          echo "EDGE_IMAGE=$REF" >> "$GITHUB_ENV"
+
       - name: Terraform apply
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -var "image_tag=$IMAGE_TAG"
-
-      - name: Show Function URL
-        working-directory: ${{ env.TF_DIR }}
-        run: terraform output -raw function_url
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-
-      # Register the slash commands. The bot token is read from SSM at run time
-      # (never stored in GitHub) and lives only in this step's environment.
-      - name: Register slash commands
-        env:
-          DISCORD_APP_ID: ${{ vars.DISCORD_APP_ID }}
-          DISCORD_GUILD_ID: ${{ github.event.inputs.guild_id }}
         run: |
-          TOKEN="$(aws ssm get-parameter \
-            --name /petbot/interactions/discord_bot_token \
-            --with-decryption --query Parameter.Value --output text)"
-          # Mask it in the Actions log: if anything ever echoes it, it shows as ***.
-          echo "::add-mask::$TOKEN"
-          # The [interactions] extra brings pynacl, which register's import chain
-          # (app -> handler -> verify) needs.
-          DISCORD_BOT_TOKEN="$TOKEN" uv run --extra interactions --python 3.12 \
-            python -m petbot.frontends.interactions.register
+          terraform apply -auto-approve \
+            -var "image_tag=$IMAGE_TAG" \
+            -var "edge_image=$EDGE_IMAGE"
+
+      - name: Show outputs
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform output -raw core_function_arn; echo
+          terraform output -raw edge_container_service_name; echo

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,57 @@
+name: Images
+
+# Build (do NOT push) both deploy images on every PR/branch that touches them, so
+# a broken Dockerfile or dependency surfaces at review time — not at a master
+# deploy. No AWS credentials or registry access needed. Each image builds on its
+# native runner arch (worker arm64, edge amd64) so there's no slow emulation.
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "deploy/Dockerfile.lambda"
+      - "deploy/Dockerfile.edge"
+      - "src/**"
+      - "pyproject.toml"
+      - ".github/workflows/images.yml"
+  pull_request:
+    paths:
+      - "deploy/Dockerfile.lambda"
+      - "deploy/Dockerfile.edge"
+      - "src/**"
+      - "pyproject.toml"
+      - ".github/workflows/images.yml"
+
+concurrency:
+  group: images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  worker:
+    name: Build core worker image (arm64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile.lambda
+          platforms: linux/arm64
+          push: false
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
+  edge:
+    name: Build edge image (amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile.edge
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=edge
+          cache-to: type=gha,mode=max,scope=edge

--- a/deploy/Dockerfile.edge
+++ b/deploy/Dockerfile.edge
@@ -1,0 +1,38 @@
+# PetBot edge image — the always-on Discord gateway holder.
+#
+# The edge holds the gateway WebSocket and dispatches each @mention to the core
+# worker Lambda (transport=lambda, via boto3). It carries no skill code: just
+# discord.py, httpx, and boto3 (the `lambda` extra). Runs on a Lightsail
+# container service (linux/amd64), so build amd64 — unlike the worker Lambda,
+# which is arm64.
+#
+# Build from the repository root:
+#
+#   docker build --platform linux/amd64 -f deploy/Dockerfile.edge -t <ref> .
+#
+# Keep the runtime in lockstep with what CI tests (pyproject requires-python,
+# mypy, ruff all target 3.12).
+FROM --platform=linux/amd64 python:3.12-slim
+
+# uv resolves + installs far faster than pip. Pinned to an immutable version tag.
+COPY --from=ghcr.io/astral-sh/uv:0.8.17 /uv /bin/uv
+
+WORKDIR /app
+
+# PetBot is one package; install only the edge + lambda extras so the image
+# carries discord.py + boto3 and not pydantic-ai / numpy.
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# `.[edge,lambda]` = the gateway edge plus the boto3 dispatch transport. No
+# secrets are baked in — the runner supplies the Discord token, the worker target,
+# and the scoped AWS key as environment variables.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system --compile-bytecode ".[edge,lambda]"
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 10001 petbot
+USER petbot
+
+# The console script defined in pyproject ([project.scripts] petbot-edge).
+CMD ["petbot-edge"]

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,18 +1,35 @@
-# PetBot interactions Lambda — Terraform
+# PetBot deploy — Terraform
 
-Infrastructure-as-code for the serverless HTTP-Interactions frontend (epic #28,
-issue #30): an AWS Lambda **container image** behind a **Function URL**, with a
-least-privilege IAM role. The Function URL output is what #31 sets as Discord's
-Interactions Endpoint URL.
+Infrastructure-as-code for PetBot 2.1: two deployables over one neutral core.
+
+- **Core worker** — an AWS **Lambda** (container image) hosting math + booru
+  search + the chat agent. It is **private**: no Function URL. The edge invokes it
+  with the AWS SDK (`boto3 invoke`), authenticated by IAM.
+- **Edge** — the always-on Discord gateway holder, on an **AWS Lightsail container
+  service** (`nano`, flat-rate, public IPv4 bundled). It holds the gateway
+  WebSocket, maps each `@mention` to a dispatched call, and invokes the worker.
 
 ```
-bootstrap/        one-time encrypted S3 state bucket (local state)
-*.tf              the Lambda + ECR + IAM + Function URL stack (S3 remote state)
+bootstrap/        one-time: S3 state bucket + GitHub OIDC deploy role
+*.tf              the core worker (Lambda + ECR + IAM) and edge (Lightsail) stack
 backend.hcl.example       remote-state backend config (copy -> backend.hcl)
 terraform.tfvars.example  inputs (copy -> terraform.tfvars); no secrets here
 ```
 
-The Lambda image is built from [`../Dockerfile.lambda`](../Dockerfile.lambda).
+Images build from [`../Dockerfile.lambda`](../Dockerfile.lambda) (worker, arm64)
+and [`../Dockerfile.edge`](../Dockerfile.edge) (edge, amd64).
+
+## Topology
+
+```
+Discord ⇄ [ edge ]  --boto3 invoke (IAM)-->  [ core worker Lambda ]  math · booru · chat
+          Lightsail container service          private, no public endpoint
+```
+
+The edge carries a **scoped IAM user** whose only permission is
+`lambda:InvokeFunction` on the core worker. Its access key is injected into the
+container's environment (Lightsail container services have no IAM instance roles).
+No public, unauthenticated surface exists, so there is no LLM cost-abuse vector.
 
 ## Prerequisites
 
@@ -22,22 +39,25 @@ The Lambda image is built from [`../Dockerfile.lambda`](../Dockerfile.lambda).
   values never touch Terraform state as managed resources:
 
   ```sh
+  # The edge's Discord bot token (read into the Lightsail container env at apply).
   aws ssm put-parameter --type SecureString \
-    --name /petbot/interactions/discord_public_key --value "<application public key>"
-  # Bot token — used ONLY by the CI command-registration step (register.py),
-  # never by the Lambda at request time. Read from SSM in CI; never in GitHub.
-  aws ssm put-parameter --type SecureString \
-    --name /petbot/interactions/discord_bot_token --value "<bot token>"
-  # optional booru auth:
-  # aws ssm put-parameter --type SecureString --name /petbot/interactions/derpibooru_api_key --value "..."
+    --name /petbot/edge/discord_token --value "<bot token>"
+
+  # Chat LLM: bedrock authenticates via the worker's IAM role (no secret).
+  # For openrouter instead, store the API key and set chat_llm_kind=openrouter:
+  # aws ssm put-parameter --type SecureString \
+  #   --name /petbot/core/openrouter_api_key --value "<key>"
+
+  # Optional booru auth:
+  # aws ssm put-parameter --type SecureString --name /petbot/core/derpibooru_api_key --value "..."
   ```
 
-  > Note: the values are injected into the Lambda's environment at apply time, so
-  > they do land in Terraform **state**. The state bucket is encrypted, versioned,
-  > and private to contain this; fetching SSM at runtime (state stays secret-free)
-  > is a documented future hardening (#17).
+  > Note: SSM values referenced by Terraform are injected into the Lambda /
+  > container environment at apply time, so they do land in Terraform **state**.
+  > The state bucket is encrypted, versioned, and private to contain this;
+  > runtime SSM fetch (state stays secret-free) is a future hardening (#17).
 
-## One-time: bootstrap remote state
+## One-time: bootstrap remote state + OIDC
 
 ```sh
 cd bootstrap
@@ -49,89 +69,83 @@ cp backend.hcl.example backend.hcl   # fill in the bucket name
 
 The bootstrap stack also creates the **GitHub Actions OIDC provider** and the
 **`petbot-github-deploy` IAM role** the CI pipeline assumes (no static AWS keys).
-After applying, wire its outputs as repo **variables** (Settings → Secrets and
-variables → Actions → Variables — non-secret):
-
-```sh
-terraform -chdir=bootstrap output deploy_role_arn   # -> DEPLOY_ROLE_ARN
-```
+Wire its outputs as repo **variables** (Settings → Secrets and variables →
+Actions → Variables):
 
 | GitHub Actions variable | Value |
 | --- | --- |
 | `DEPLOY_ROLE_ARN` | `deploy_role_arn` bootstrap output |
 | `AWS_REGION` | e.g. `us-east-1` (match `backend.hcl` / your SSM region) |
 | `TF_STATE_BUCKET` | the `state_bucket` you chose above |
-| `DISCORD_APP_ID` | your Discord application ID |
 
 ## CI deploy (the steady-state path)
 
-`.github/workflows/deploy.yml` does the whole rollout via OIDC — build + push the
-arm64 image (tagged with the git SHA), `terraform apply`, then register the slash
-commands. **No deploy is ever run from a developer machine.**
+`.github/workflows/deploy.yml` does the whole rollout via OIDC: build + push the
+arm64 worker image (ECR) and the amd64 edge image (Lightsail registry), then
+`terraform apply`. A push to `master` (or a manual *Actions → Deploy → Run
+workflow*) ships it. **No deploy is run from a developer machine.**
 
-- **Roll out to one guild first (instant):** run the workflow via
-  *Actions → Deploy → Run workflow* with **`guild_id`** set to your dev/private
-  server's ID. `register.py` registers the commands guild-scoped, so they appear
-  in that guild immediately and nowhere else.
-- **Go global:** a push to `master` runs the same pipeline with an empty
-  `guild_id`, registering the commands application-wide (up to ~1h to propagate).
-- **First run only:** set Discord's *Interactions Endpoint URL* to the
-  `function_url` the workflow prints, and invite the app to the target guild
-  (`bot` + `applications.commands` scopes).
+## Deploy (manual / break-glass)
 
-## Deploy
-
-Because the function is pinned to the image digest, the image must exist before
-the main apply — so it's a two-step the first time:
+Because the worker is pinned to the image digest and the edge image needs its
+Lightsail service to exist first, the first apply is staged:
 
 ```sh
-cp terraform.tfvars.example terraform.tfvars   # adjust region, SSM names, etc.
+cp terraform.tfvars.example terraform.tfvars   # set region, chat_llm_*, SSM names
 terraform init -backend-config=backend.hcl
 
-# 1. Create just the ECR repo.
-terraform apply -target=aws_ecr_repository.this
+# 1. Create the ECR repo + the (empty) Lightsail container service.
+terraform apply -target=aws_ecr_repository.this -target=aws_lightsail_container_service.edge
 
-# 2. Build + push the arm64 image to that repo.
+# 2. Build + push the worker image (arm64) to ECR.
 REPO=$(terraform output -raw ecr_repository_url)
 aws ecr get-login-password | docker login --username AWS --password-stdin "${REPO%/*}"
 docker build --platform linux/arm64 -f ../Dockerfile.lambda -t "$REPO:latest" ../..
 docker push "$REPO:latest"
 
-# 3. Stand up the function + Function URL.
-terraform apply
+# 3. Build + push the edge image (amd64) to Lightsail; note the returned ref.
+docker build --platform linux/amd64 -f ../Dockerfile.edge -t petbot-edge:latest ../..
+aws lightsail push-container-image --service-name petbot-edge --label edge --image petbot-edge:latest
+#   -> "Refer to this image as ":petbot-edge.edge.1" ..."
 
-terraform output function_url   # -> set this as Discord's Interactions Endpoint URL (#31)
+# 4. Stand up the worker + edge deployment.
+terraform apply -var 'edge_image=:petbot-edge.edge.1'
+
+terraform output core_function_arn          # the edge's WORKER__FUNCTION_NAME target
+terraform output edge_container_service_name
 ```
 
-For subsequent deploys, push a new image (prefer a unique tag, e.g. the git SHA,
-set via `-var image_tag=...`) and re-run `terraform apply`.
+For subsequent deploys, push new images (prefer a unique tag, e.g. the git SHA)
+and re-`apply` with the new `image_tag` / `edge_image`.
+
+## Migrating from the old interactions stack (one-time)
+
+PetBot 2.0 deployed a single public **interactions** Lambda (`petbot-interactions`,
+state key `interactions/terraform.tfstate`). 2.1 replaces it with the private core
+worker + the edge, under a new state key (`petbot/terraform.tfstate`) and new
+names. The old stack is **decommissioned**: once, run `terraform destroy` against
+the old `interactions/…` state (or delete the orphaned function, ECR repo, and
+role in the console). Nothing imports from the old state.
 
 ## Cost & retention
 
-The stack keeps storage bounded and `destroy` complete:
-
-- **ECR lifecycle** (`retention.tf`) expires untagged images after
-  `ecr_untagged_expire_days` and keeps only the last `ecr_keep_last_images`.
-- **CloudWatch Logs** are an explicit `aws_cloudwatch_log_group` with
-  `log_retention_days` retention — so logs don't accumulate forever, and
-  `terraform destroy` removes the group (Lambda's auto-created one never expires
-  and wouldn't be owned by Terraform).
-- **Cost alerts** are opt-in: AWS has no hard spend cap, so set
-  `monthly_budget_usd` + `budget_alert_emails` to create an AWS Budget that
-  emails you at 80% and 100% of the limit. At PetBot's scale spend is ~$0, so
-  this is a smoke alarm, not a throttle.
+- **Edge:** Lightsail `nano` ~$7/mo flat (public IPv4 + 500 GB transfer bundled).
+- **Worker:** Lambda — ~$0 at this scale (scale-to-zero); chat inference is the
+  only real variable (cents–low-$/mo).
+- **ECR lifecycle** (`retention.tf`) expires old/untagged worker images.
+- **CloudWatch Logs** retain `log_retention_days`; the group is owned here so
+  `terraform destroy` removes it.
+- **Cost alerts** are opt-in: set `monthly_budget_usd` + `budget_alert_emails`.
 
 ## Teardown
 
 ```sh
 terraform destroy
-# and, if you want to remove state storage too:
 cd bootstrap && terraform destroy -var "state_bucket=petbot-tfstate-<your-account-id>"
 ```
 
-## CI
+## CI checks
 
 `.github/workflows/terraform.yml` runs `fmt -check` + `validate` on PRs (no AWS
-credentials needed). `.github/workflows/deploy.yml` runs the full OIDC
-build/apply/register pipeline (see **CI deploy** above). The manual two-step
-`terraform apply` flow above remains valid for local/break-glass use.
+credentials needed). `.github/workflows/deploy.yml` runs the OIDC build/apply
+pipeline above.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -31,6 +31,12 @@ The edge carries a **scoped IAM user** whose only permission is
 container's environment (Lightsail container services have no IAM instance roles).
 No public, unauthenticated surface exists, so there is no LLM cost-abuse vector.
 
+Both images live in **ECR**. The worker Lambda runs its image directly; the edge
+**pulls** its image from ECR via Lightsail's private-registry access (an
+auto-created "image puller" principal that `edge.tf` grants read on the edge
+repo). One registry, one push mechanism — no `lightsailctl`, no image-ref
+scraping.
+
 ## Prerequisites
 
 - An AWS account with credentials in your shell (e.g. `aws sso login`).
@@ -69,54 +75,60 @@ cp backend.hcl.example backend.hcl   # fill in the bucket name
 
 The bootstrap stack also creates the **GitHub Actions OIDC provider** and the
 **`petbot-github-deploy` IAM role** the CI pipeline assumes (no static AWS keys).
-Wire its outputs as repo **variables** (Settings → Secrets and variables →
-Actions → Variables):
+Set the following repo **Variables** (Settings → Secrets and variables → Actions
+→ Variables — these are non-secret; the actual secret *values* live in SSM,
+referenced here only by parameter name). The deploy reads them as `TF_VAR_*`:
 
-| GitHub Actions variable | Value |
-| --- | --- |
-| `DEPLOY_ROLE_ARN` | `deploy_role_arn` bootstrap output |
-| `AWS_REGION` | e.g. `us-east-1` (match `backend.hcl` / your SSM region) |
-| `TF_STATE_BUCKET` | the `state_bucket` you chose above |
+| GitHub Actions variable | Value | Where it comes from |
+| --- | --- | --- |
+| `DEPLOY_ROLE_ARN` | the deploy role ARN | `terraform -chdir=bootstrap output deploy_role_arn` |
+| `AWS_REGION` | e.g. `us-east-1` | your choice (match `backend.hcl` / SSM region) |
+| `TF_STATE_BUCKET` | the state bucket name | the `state_bucket` you chose above |
+| `CHAT_LLM_KIND` | `bedrock` or `openrouter` | your choice of provider |
+| `CHAT_LLM_MODEL` | the model id | a Bedrock model/inference-profile id, or an OpenRouter model id |
+| `CHAT_LLM_API_KEY_SSM_PARAMETER` | e.g. `/petbot/core/openrouter_api_key` | **only** for `openrouter`; leave unset for `bedrock` |
+
+That's the complete list — once these Variables and the SSM secrets above exist,
+a push to `master` runs a green deploy. (Merging the PR alone does **not** create
+them; this one-time setup is yours to do.)
 
 ## CI deploy (the steady-state path)
 
-`.github/workflows/deploy.yml` does the whole rollout via OIDC: build + push the
-arm64 worker image (ECR) and the amd64 edge image (Lightsail registry), then
-`terraform apply`. A push to `master` (or a manual *Actions → Deploy → Run
-workflow*) ships it. **No deploy is run from a developer machine.**
+`.github/workflows/deploy.yml` does the whole rollout via OIDC: build + push both
+images to ECR (arm64 worker, amd64 edge), then `terraform apply` (the Lightsail
+edge pulls its image from ECR). A push to `master` (or a manual *Actions → Deploy
+→ Run workflow*) ships it. **No deploy is run from a developer machine.**
 
 ## Deploy (manual / break-glass)
 
-Because the worker is pinned to the image digest and the edge image needs its
-Lightsail service to exist first, the first apply is staged:
+Because the function is pinned to its image digest and the edge service must grant
+ECR-pull access before the edge deployment is created, the first apply is staged:
 
 ```sh
 cp terraform.tfvars.example terraform.tfvars   # set region, chat_llm_*, SSM names
 terraform init -backend-config=backend.hcl
 
-# 1. Create the ECR repo + the (empty) Lightsail container service.
-terraform apply -target=aws_ecr_repository.this -target=aws_lightsail_container_service.edge
+# 1. Create both ECR repos, the Lightsail service, and the edge repo policy.
+terraform apply \
+  -target=aws_ecr_repository.this -target=aws_ecr_repository.edge \
+  -target=aws_lightsail_container_service.edge -target=aws_ecr_repository_policy.edge
 
-# 2. Build + push the worker image (arm64) to ECR.
-REPO=$(terraform output -raw ecr_repository_url)
-aws ecr get-login-password | docker login --username AWS --password-stdin "${REPO%/*}"
-docker build --platform linux/arm64 -f ../Dockerfile.lambda -t "$REPO:latest" ../..
-docker push "$REPO:latest"
+# 2. Push both images to ECR (one login covers both repos).
+CORE=$(terraform output -raw ecr_repository_url)
+EDGE=$(terraform output -raw edge_ecr_repository_url)
+aws ecr get-login-password | docker login --username AWS --password-stdin "${CORE%/*}"
+docker build --platform linux/arm64 -f ../Dockerfile.lambda -t "$CORE:latest" ../.. && docker push "$CORE:latest"
+docker build --platform linux/amd64 -f ../Dockerfile.edge   -t "$EDGE:latest" ../.. && docker push "$EDGE:latest"
 
-# 3. Build + push the edge image (amd64) to Lightsail; note the returned ref.
-docker build --platform linux/amd64 -f ../Dockerfile.edge -t petbot-edge:latest ../..
-aws lightsail push-container-image --service-name petbot-edge --label edge --image petbot-edge:latest
-#   -> "Refer to this image as ":petbot-edge.edge.1" ..."
-
-# 4. Stand up the worker + edge deployment.
-terraform apply -var 'edge_image=:petbot-edge.edge.1'
+# 3. Stand up the worker + edge deployment (the edge pulls its image from ECR).
+terraform apply -var 'image_tag=latest' -var 'edge_image_tag=latest'
 
 terraform output core_function_arn          # the edge's WORKER__FUNCTION_NAME target
 terraform output edge_container_service_name
 ```
 
 For subsequent deploys, push new images (prefer a unique tag, e.g. the git SHA)
-and re-`apply` with the new `image_tag` / `edge_image`.
+and re-`apply` with the new `image_tag` / `edge_image_tag`.
 
 ## Migrating from the old interactions stack (one-time)
 
@@ -132,7 +144,7 @@ role in the console). Nothing imports from the old state.
 - **Edge:** Lightsail `nano` ~$7/mo flat (public IPv4 + 500 GB transfer bundled).
 - **Worker:** Lambda — ~$0 at this scale (scale-to-zero); chat inference is the
   only real variable (cents–low-$/mo).
-- **ECR lifecycle** (`retention.tf`) expires old/untagged worker images.
+- **ECR lifecycle** (`retention.tf`) expires old/untagged images in both repos.
 - **CloudWatch Logs** retain `log_retention_days`; the group is owned here so
   `terraform destroy` removes it.
 - **Cost alerts** are opt-in: set `monthly_budget_usd` + `budget_alert_emails`.

--- a/deploy/terraform/backend.hcl.example
+++ b/deploy/terraform/backend.hcl.example
@@ -3,7 +3,7 @@
 # The bucket is created by deploy/terraform/bootstrap. State locking is native
 # to S3 via use_lockfile (Terraform >= 1.11) — no DynamoDB table required.
 bucket       = "petbot-tfstate-<your-account-id>"
-key          = "interactions/terraform.tfstate"
+key          = "petbot/terraform.tfstate"
 region       = "us-east-1"
 encrypt      = true
 use_lockfile = true

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -131,11 +131,12 @@ locals {
   # Every resource the deploy role may touch is one of the named stack resources
   # below; scoping to these ARNs means a stolen CI token can't reach anything
   # else in the account.
-  lambda_arn    = "arn:aws:lambda:${var.aws_region}:${local.account_id}:function:${local.core_name}"
-  ecr_repo_arn  = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${local.core_name}"
-  log_group_arn = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${local.core_name}"
-  exec_role_arn = "arn:aws:iam::${local.account_id}:role/${local.core_name}-role"
-  edge_user_arn = "arn:aws:iam::${local.account_id}:user/${local.edge_name}"
+  lambda_arn        = "arn:aws:lambda:${var.aws_region}:${local.account_id}:function:${local.core_name}"
+  ecr_repo_arn      = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${local.core_name}"
+  edge_ecr_repo_arn = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${local.edge_name}"
+  log_group_arn     = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${local.core_name}"
+  exec_role_arn     = "arn:aws:iam::${local.account_id}:role/${local.core_name}-role"
+  edge_user_arn     = "arn:aws:iam::${local.account_id}:user/${local.edge_name}"
 }
 
 # Least-privilege permissions for the deploy workflow. Service-level action
@@ -176,10 +177,12 @@ data "aws_iam_policy_document" "deploy_permissions" {
     resources = ["*"]
   }
 
+  # Manage both ECR repos (worker + edge), including their lifecycle and the
+  # edge repo's policy (set so the Lightsail puller principal can read it).
   statement {
-    sid       = "ManageEcrRepo"
+    sid       = "ManageEcrRepos"
     actions   = ["ecr:*"]
-    resources = [local.ecr_repo_arn]
+    resources = [local.ecr_repo_arn, local.edge_ecr_repo_arn]
   }
 
   statement {

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -40,8 +40,8 @@ variable "github_repo" {
 
 variable "name_prefix" {
   type        = string
-  description = "Must match var.name_prefix in the root stack; used to scope the deploy role's permissions to exactly that stack's resources."
-  default     = "petbot-interactions"
+  description = "Must match var.name_prefix in the root stack; used to scope the deploy role's permissions to exactly that stack's resources (<name_prefix>-core / -edge)."
+  default     = "petbot"
 }
 
 resource "aws_s3_bucket" "state" {
@@ -125,14 +125,17 @@ resource "aws_iam_role" "github_deploy" {
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  core_name  = "${var.name_prefix}-core"
+  edge_name  = "${var.name_prefix}-edge"
 
   # Every resource the deploy role may touch is one of the named stack resources
   # below; scoping to these ARNs means a stolen CI token can't reach anything
   # else in the account.
-  lambda_arn    = "arn:aws:lambda:${var.aws_region}:${local.account_id}:function:${var.name_prefix}"
-  ecr_repo_arn  = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${var.name_prefix}"
-  log_group_arn = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${var.name_prefix}"
-  exec_role_arn = "arn:aws:iam::${local.account_id}:role/${var.name_prefix}-role"
+  lambda_arn    = "arn:aws:lambda:${var.aws_region}:${local.account_id}:function:${local.core_name}"
+  ecr_repo_arn  = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${local.core_name}"
+  log_group_arn = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${local.core_name}"
+  exec_role_arn = "arn:aws:iam::${local.account_id}:role/${local.core_name}-role"
+  edge_user_arn = "arn:aws:iam::${local.account_id}:user/${local.edge_name}"
 }
 
 # Least-privilege permissions for the deploy workflow. Service-level action
@@ -149,7 +152,7 @@ data "aws_iam_policy_document" "deploy_permissions" {
   statement {
     sid       = "ReadRuntimeSecrets"
     actions   = ["ssm:GetParameter", "ssm:GetParameters"]
-    resources = ["arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/petbot/interactions/*"]
+    resources = ["arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/petbot/*"]
   }
 
   # SecureString parameters are KMS-encrypted; reading them with decryption needs
@@ -239,6 +242,38 @@ data "aws_iam_policy_document" "deploy_permissions" {
       variable = "iam:PassedToService"
       values   = ["lambda.amazonaws.com"]
     }
+  }
+
+  # The edge runs on Lightsail's container service. Lightsail resources are
+  # identified by random-GUID ARNs, so there is no name-based ARN to scope to —
+  # the same reason ecr:* / lambda:* above are kept as service-level wildcards.
+  # The blast radius is the account's Lightsail, which holds only this edge.
+  statement {
+    sid       = "ManageEdgeContainerService"
+    actions   = ["lightsail:*"]
+    resources = ["*"]
+  }
+
+  # Create/manage only the scoped edge IAM user + its access key and inline policy
+  # (the edge's identity for invoking the worker Lambda — see edge.tf).
+  statement {
+    sid = "ManageEdgeUser"
+    actions = [
+      "iam:GetUser",
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:TagUser",
+      "iam:UntagUser",
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+      "iam:GetUserPolicy",
+      "iam:PutUserPolicy",
+      "iam:DeleteUserPolicy",
+      "iam:ListUserPolicies",
+      "iam:ListAttachedUserPolicies",
+    ]
+    resources = [local.edge_user_arn]
   }
 }
 

--- a/deploy/terraform/edge.tf
+++ b/deploy/terraform/edge.tf
@@ -8,27 +8,69 @@
 # container still runs, reachable only on the private `<name>.service.local`
 # domain (which the edge never needs), and no health-check port is required.
 #
-# Image must be linux/amd64 (Lightsail container services are amd64-only; an
+# Image delivery is ECR-pull: the edge image lives in its own ECR repo (the same
+# registry the worker uses), and the service pulls it via an "image puller" IAM
+# role (the declarative equivalent of what the Lightsail console wires up). The
+# image must be linux/amd64 (Lightsail container services are amd64-only; an
 # arm64 image fails with "exec format error") — see Dockerfile.edge. Measured edge
-# footprint ~76 MB RSS (discord.py + httpx + boto3), so `nano` (512 MB) is ample;
-# bump var.edge_power to `micro` if it ever OOMs.
+# footprint ~76 MB RSS, so `nano` (512 MB) is ample; bump var.edge_power to
+# `micro` if it ever OOMs.
 
 resource "aws_lightsail_container_service" "edge" {
   name  = local.edge_name
   power = var.edge_power
   scale = var.edge_scale
+
+  # Activating this creates an AWS-managed ECR "image puller" principal for the
+  # service; we grant it read on the edge repo below. (Same-Region requirement:
+  # the repo and the service are both in var.aws_region.)
+  private_registry_access {
+    ecr_image_puller_role {
+      is_active = true
+    }
+  }
 }
 
-# The container deployment. Skipped until an image has been pushed (var.edge_image
-# empty), so the service can be created first, then the image pushed, then this
-# set — mirroring the ECR-first two-step for the worker.
+# The edge's own ECR repository.
+resource "aws_ecr_repository" "edge" {
+  name                 = local.edge_name
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# Grant the service's puller principal read access on the edge repo — exactly the
+# statement the Lightsail console would add for you, here as code. The principal
+# ARN is populated once the puller role is active; Terraform orders this after the
+# service create because it references that attribute.
+resource "aws_ecr_repository_policy" "edge" {
+  repository = aws_ecr_repository.edge.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "AllowLightsailPull"
+      Effect    = "Allow"
+      Principal = { AWS = aws_lightsail_container_service.edge.private_registry_access[0].ecr_image_puller_role[0].principal_arn }
+      Action    = ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"]
+    }]
+  })
+}
+
+# The container deployment. Skipped until an image tag is supplied (CI pushes the
+# image to ECR, then passes its tag), so the service + puller can be created
+# first. Lightsail pulls from ECR using the puller role, so the repo policy must
+# exist before the deployment is created.
 resource "aws_lightsail_container_service_deployment_version" "edge" {
-  count        = var.edge_image != "" ? 1 : 0
+  count        = var.edge_image_tag != "" ? 1 : 0
   service_name = aws_lightsail_container_service.edge.name
 
   container {
     container_name = "edge"
-    image          = var.edge_image
+    image          = "${aws_ecr_repository.edge.repository_url}:${var.edge_image_tag}"
 
     environment = {
       LOG_LEVEL             = var.log_level
@@ -43,6 +85,8 @@ resource "aws_lightsail_container_service_deployment_version" "edge" {
       DISCORD_TOKEN         = data.aws_ssm_parameter.discord_token.value
     }
   }
+
+  depends_on = [aws_ecr_repository_policy.edge]
 }
 
 data "aws_ssm_parameter" "discord_token" {

--- a/deploy/terraform/edge.tf
+++ b/deploy/terraform/edge.tf
@@ -1,0 +1,76 @@
+# --- The always-on edge: a Lightsail container service ------------------------
+#
+# The edge holds the Discord gateway (an outbound WebSocket) and dispatches each
+# @mention to the core worker Lambda. Lightsail container service is the host:
+# flat-rate, public IPv4 + data bundled, immutable container push (no box to
+# patch). It serves no HTTP — it only dials out to Discord and to the worker — so
+# the deployment configures NO public endpoint. Lightsail supports this: the
+# container still runs, reachable only on the private `<name>.service.local`
+# domain (which the edge never needs), and no health-check port is required.
+#
+# Image must be linux/amd64 (Lightsail container services are amd64-only; an
+# arm64 image fails with "exec format error") — see Dockerfile.edge. Measured edge
+# footprint ~76 MB RSS (discord.py + httpx + boto3), so `nano` (512 MB) is ample;
+# bump var.edge_power to `micro` if it ever OOMs.
+
+resource "aws_lightsail_container_service" "edge" {
+  name  = local.edge_name
+  power = var.edge_power
+  scale = var.edge_scale
+}
+
+# The container deployment. Skipped until an image has been pushed (var.edge_image
+# empty), so the service can be created first, then the image pushed, then this
+# set — mirroring the ECR-first two-step for the worker.
+resource "aws_lightsail_container_service_deployment_version" "edge" {
+  count        = var.edge_image != "" ? 1 : 0
+  service_name = aws_lightsail_container_service.edge.name
+
+  container {
+    container_name = "edge"
+    image          = var.edge_image
+
+    environment = {
+      LOG_LEVEL             = var.log_level
+      ENV                   = var.lambda_environment
+      WORKER__KIND          = "lambda"
+      WORKER__FUNCTION_NAME = aws_lambda_function.this.function_name
+      AWS_REGION            = var.aws_region
+      # Scoped identity for boto3's default credential chain (Lightsail container
+      # services have no IAM instance roles, so a static key is the mechanism).
+      AWS_ACCESS_KEY_ID     = aws_iam_access_key.edge.id
+      AWS_SECRET_ACCESS_KEY = aws_iam_access_key.edge.secret
+      DISCORD_TOKEN         = data.aws_ssm_parameter.discord_token.value
+    }
+  }
+}
+
+data "aws_ssm_parameter" "discord_token" {
+  name            = var.discord_token_ssm_parameter
+  with_decryption = true
+}
+
+# --- The edge's scoped AWS identity -------------------------------------------
+# Least privilege: invoke exactly the core worker Lambda, nothing else.
+
+resource "aws_iam_user" "edge" {
+  name = local.edge_name
+}
+
+resource "aws_iam_access_key" "edge" {
+  user = aws_iam_user.edge.name
+}
+
+resource "aws_iam_user_policy" "edge_invoke" {
+  name = "${local.edge_name}-invoke-core"
+  user = aws_iam_user.edge.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "lambda:InvokeFunction"
+      Resource = aws_lambda_function.this.arn
+    }]
+  })
+}

--- a/deploy/terraform/locals.tf
+++ b/deploy/terraform/locals.tf
@@ -1,0 +1,7 @@
+# Two deployables share this stack: the core worker (Lambda) and the edge
+# (Lightsail container service). Their resource names derive from one prefix so
+# the bootstrap deploy role can scope to `${name_prefix}-core*` / `-edge*`.
+locals {
+  core_name = "${var.name_prefix}-core"
+  edge_name = "${var.name_prefix}-edge"
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,7 +1,7 @@
 # --- Container image registry -------------------------------------------------
 
 resource "aws_ecr_repository" "this" {
-  name                 = var.name_prefix
+  name                 = local.core_name
   image_tag_mutability = "MUTABLE"
   force_delete         = true
 
@@ -20,6 +20,8 @@ data "aws_ecr_image" "this" {
 
 # --- Execution role -----------------------------------------------------------
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "assume" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -32,7 +34,7 @@ data "aws_iam_policy_document" "assume" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = "${var.name_prefix}-role"
+  name               = "${local.core_name}-role"
   assume_role_policy = data.aws_iam_policy_document.assume.json
 }
 
@@ -44,10 +46,31 @@ resource "aws_iam_role_policy_attachment" "logs" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-# --- Function + public URL ----------------------------------------------------
+# Bedrock chat: the agent invokes a foundation model / inference profile in this
+# region. Only attached when the chat provider is bedrock (openrouter authes with
+# an API key in the environment instead, so it needs no AWS permission).
+resource "aws_iam_role_policy" "bedrock" {
+  count = var.chat_llm_kind == "bedrock" ? 1 : 0
+  name  = "${local.core_name}-bedrock"
+  role  = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
+      Resource = [
+        "arn:aws:bedrock:${var.aws_region}::foundation-model/*",
+        "arn:aws:bedrock:${var.aws_region}:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+      ]
+    }]
+  })
+}
+
+# --- Function -----------------------------------------------------------------
 
 resource "aws_lambda_function" "this" {
-  function_name = var.name_prefix
+  function_name = local.core_name
   role          = aws_iam_role.lambda.arn
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.this.repository_url}@${data.aws_ecr_image.this.image_digest}"
@@ -64,17 +87,5 @@ resource "aws_lambda_function" "this" {
   depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
-resource "aws_lambda_function_url" "this" {
-  function_name      = aws_lambda_function.this.function_name
-  authorization_type = "NONE"
-}
-
-# AUTH_NONE still requires an explicit public-invoke permission; the security
-# boundary is the Ed25519 signature the handler verifies, not IAM.
-resource "aws_lambda_permission" "function_url" {
-  statement_id           = "FunctionURLAllowPublicAccess"
-  action                 = "lambda:InvokeFunctionUrl"
-  function_name          = aws_lambda_function.this.function_name
-  principal              = "*"
-  function_url_auth_type = "NONE"
-}
+# No Function URL: the worker is private. The edge invokes it with the AWS SDK
+# (boto3 `invoke`), authenticated by the edge's scoped IAM identity (see edge.tf).

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -13,7 +13,12 @@ output "ecr_repository_url" {
   value       = aws_ecr_repository.this.repository_url
 }
 
+output "edge_ecr_repository_url" {
+  description = "Push the edge image here; the Lightsail service pulls it from this repo."
+  value       = aws_ecr_repository.edge.repository_url
+}
+
 output "edge_container_service_name" {
-  description = "Lightsail container service hosting the edge; push the edge image to it."
+  description = "Lightsail container service hosting the edge."
   value       = aws_lightsail_container_service.edge.name
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,14 +1,19 @@
-output "function_url" {
-  description = "Public HTTPS endpoint. Paste into Discord's Interactions Endpoint URL (#31)."
-  value       = aws_lambda_function_url.this.function_url
+output "core_function_name" {
+  description = "Name of the core worker Lambda (the edge's WORKER__FUNCTION_NAME)."
+  value       = aws_lambda_function.this.function_name
+}
+
+output "core_function_arn" {
+  description = "ARN of the core worker Lambda; the edge's IAM user is granted lambda:InvokeFunction on it."
+  value       = aws_lambda_function.this.arn
 }
 
 output "ecr_repository_url" {
-  description = "Push the Lambda image here before the main apply."
+  description = "Push the core worker Lambda image here before the main apply."
   value       = aws_ecr_repository.this.repository_url
 }
 
-output "lambda_function_name" {
-  description = "Name of the deployed interactions function."
-  value       = aws_lambda_function.this.function_name
+output "edge_container_service_name" {
+  description = "Lightsail container service hosting the edge; push the edge image to it."
+  value       = aws_lightsail_container_service.edge.name
 }

--- a/deploy/terraform/providers.tf
+++ b/deploy/terraform/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
   default_tags {
     tags = {
       Project   = "petbot"
-      Component = "interactions-lambda"
+      Component = "edge-and-core-worker"
       ManagedBy = "terraform"
     }
   }

--- a/deploy/terraform/retention.tf
+++ b/deploy/terraform/retention.tf
@@ -35,6 +35,6 @@ resource "aws_ecr_lifecycle_policy" "this" {
 resource "aws_cloudwatch_log_group" "lambda" {
   # Lambda writes to /aws/lambda/<function-name>; creating it explicitly lets us
   # set retention (and own its lifecycle) instead of the never-expire default.
-  name              = "/aws/lambda/${var.name_prefix}"
+  name              = "/aws/lambda/${local.core_name}"
   retention_in_days = var.log_retention_days
 }

--- a/deploy/terraform/retention.tf
+++ b/deploy/terraform/retention.tf
@@ -2,10 +2,10 @@
 # forever. Managing the log group here also means `terraform destroy` removes it
 # (otherwise Lambda auto-creates a never-expiring group that TF wouldn't own).
 
-resource "aws_ecr_lifecycle_policy" "this" {
-  repository = aws_ecr_repository.this.name
-
-  policy = jsonencode({
+locals {
+  # Shared lifecycle for both ECR repos (worker + edge): expire untagged images,
+  # and keep only the most recent tagged ones.
+  ecr_lifecycle_policy = jsonencode({
     rules = [
       {
         rulePriority = 1
@@ -30,6 +30,16 @@ resource "aws_ecr_lifecycle_policy" "this" {
       },
     ]
   })
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+  policy     = local.ecr_lifecycle_policy
+}
+
+resource "aws_ecr_lifecycle_policy" "edge" {
+  repository = aws_ecr_repository.edge.name
+  policy     = local.ecr_lifecycle_policy
 }
 
 resource "aws_cloudwatch_log_group" "lambda" {

--- a/deploy/terraform/secrets.tf
+++ b/deploy/terraform/secrets.tf
@@ -1,5 +1,5 @@
 # Runtime secrets are stored as SSM SecureString parameters created out-of-band
-# (see README) and read here to populate the Lambda's environment. The bot only
+# (see README) and read here to populate the Lambda's environment. The worker only
 # ever reads os.environ, so the app stays platform-agnostic.
 #
 # Trade-off (flagged for review): injecting via the Lambda environment means the
@@ -8,9 +8,21 @@
 # Keeping state fully secret-free would require the function to fetch SSM at
 # runtime instead — a documented future hardening (tracked with secrets/ops #17).
 
-data "aws_ssm_parameter" "public_key" {
-  name            = var.public_key_ssm_parameter
+# OpenRouter API key — only when that provider is selected. Bedrock authenticates
+# with the exec role's IAM policy (main.tf), so it needs no secret here.
+data "aws_ssm_parameter" "chat_api_key" {
+  count           = var.chat_llm_kind == "openrouter" ? 1 : 0
+  name            = var.chat_llm_api_key_ssm_parameter
   with_decryption = true
+
+  # Fail at plan with a clear message instead of an opaque "name is required"
+  # SSM error when the param name was left empty for the openrouter provider.
+  lifecycle {
+    precondition {
+      condition     = trimspace(var.chat_llm_api_key_ssm_parameter) != ""
+      error_message = "chat_llm_kind=openrouter requires chat_llm_api_key_ssm_parameter (the SSM SecureString holding the key)."
+    }
+  }
 }
 
 data "aws_ssm_parameter" "booru" {
@@ -24,12 +36,16 @@ locals {
     {
       ENV       = var.lambda_environment
       LOG_LEVEL = var.log_level
+      # The chat agent's provider config, as the nested env the worker's
+      # ChatSettings reads (CHAT_LLM__KIND / CHAT_LLM__MODEL[ / __API_KEY]).
+      CHAT_LLM__KIND  = var.chat_llm_kind
+      CHAT_LLM__MODEL = var.chat_llm_model
     },
     var.user_agent != "" ? { USER_AGENT = var.user_agent } : {},
   )
 
   secret_env = merge(
-    { DISCORD_PUBLIC_KEY = data.aws_ssm_parameter.public_key.value },
+    var.chat_llm_kind == "openrouter" ? { CHAT_LLM__API_KEY = data.aws_ssm_parameter.chat_api_key[0].value } : {},
     { for env_name, param in data.aws_ssm_parameter.booru : env_name => param.value },
   )
 

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -28,7 +28,7 @@ chat_llm_model = "" # REQUIRED — set to a Bedrock model/inference-profile id, 
 discord_token_ssm_parameter = "/petbot/edge/discord_token"
 edge_power                  = "nano" # 0.25 vCPU / 512 MB; bump to "micro" (1 GB) if it OOMs
 edge_scale                  = 1
-# edge_image is supplied by CI after `aws lightsail push-container-image`.
+# edge_image_tag is supplied by CI (the git SHA) after pushing the edge image to ECR.
 
 # --- Retention / cost (sensible defaults; override to taste) ---
 # log_retention_days       = 30

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -4,21 +4,31 @@
 # us-east-1 is AWS's cheapest US region and where ACM/CloudFront (future custom
 # domain) must live. us-east-2 / us-west-2 cost the same; pick one if you prefer.
 aws_region = "us-east-1"
-image_tag  = "latest" # prefer a unique tag per deploy, e.g. the git SHA
+image_tag  = "latest" # core worker image; prefer a unique tag per deploy, e.g. the git SHA
 
 # ENV drives the logging profile (prod => structured JSON).
 lambda_environment = "prod"
 log_level          = "INFO"
 
-# Required SSM SecureString holding the Discord application public key.
-public_key_ssm_parameter = "/petbot/interactions/discord_public_key"
+# --- Chat LLM (the core worker's agent) ---
+# bedrock authenticates via the exec role's IAM (no secret); openrouter needs a key.
+chat_llm_kind  = "bedrock"
+chat_llm_model = "" # REQUIRED — set to a Bedrock model/inference-profile id, or an OpenRouter model id
+# Only for openrouter: SSM SecureString holding the API key.
+# chat_llm_api_key_ssm_parameter = "/petbot/core/openrouter_api_key"
 
 # Optional booru auth: ENV-VAR-NAME => SSM-parameter-name.
 # booru_ssm_parameters = {
-#   DERPIBOORU_API_KEY = "/petbot/interactions/derpibooru_api_key"
-#   E621_USERNAME      = "/petbot/interactions/e621_username"
-#   E621_API_KEY       = "/petbot/interactions/e621_api_key"
+#   DERPIBOORU_API_KEY = "/petbot/core/derpibooru_api_key"
+#   E621_USERNAME      = "/petbot/core/e621_username"
+#   E621_API_KEY       = "/petbot/core/e621_api_key"
 # }
+
+# --- Edge (Lightsail container service) ---
+discord_token_ssm_parameter = "/petbot/edge/discord_token"
+edge_power                  = "nano" # 0.25 vCPU / 512 MB; bump to "micro" (1 GB) if it OOMs
+edge_scale                  = 1
+# edge_image is supplied by CI after `aws lightsail push-container-image`.
 
 # --- Retention / cost (sensible defaults; override to taste) ---
 # log_retention_days       = 30

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -154,13 +154,12 @@ variable "edge_scale" {
   default     = 1
 }
 
-variable "edge_image" {
+variable "edge_image_tag" {
   type        = string
   description = <<-EOT
-    Image ref for the edge container, as returned by `aws lightsail
-    push-container-image` (e.g. ":petbot-edge.edge.1"). CI pushes the image and
-    passes this in; empty leaves the service with no deployment (apply the
-    service first, then push + set this — see README).
+    Tag of the edge image in its ECR repo (CI sets this to the git SHA). The
+    Lightsail service pulls `<edge-ecr-repo>:<tag>`. Empty leaves the service
+    with no deployment (apply the service first, then push + set this).
   EOT
   default     = ""
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -15,8 +15,8 @@ variable "aws_region" {
 
 variable "name_prefix" {
   type        = string
-  description = "Name applied to the Lambda, ECR repo, and IAM role."
-  default     = "petbot-interactions"
+  description = "Base name for the stack; resources derive <name_prefix>-core / -edge (see locals.tf)."
+  default     = "petbot"
 }
 
 variable "image_tag" {
@@ -55,18 +55,41 @@ variable "memory_size" {
 
 variable "timeout" {
   type        = number
-  description = "Lambda timeout (seconds). The handler caps skills well under Discord's 3s."
-  default     = 10
+  description = <<-EOT
+    Lambda timeout (seconds). The edge invokes the worker synchronously and the
+    chat agent runs an LLM tool-loop, so this is generous — not the old 3s
+    Discord-interaction bound (the edge holds the gateway, not this function).
+  EOT
+  default     = 60
 }
 
-variable "public_key_ssm_parameter" {
+# --- Chat LLM (the worker's agent) --------------------------------------------
+
+variable "chat_llm_kind" {
   type        = string
-  description = <<-EOT
-    Name of the SSM SecureString parameter holding DISCORD_PUBLIC_KEY. Created
-    out-of-band (see README) so its value is never committed; Terraform reads it
-    to populate the Lambda's environment.
-  EOT
-  default     = "/petbot/interactions/discord_public_key"
+  description = "Chat provider discriminator: \"bedrock\" (IAM-auth) or \"openrouter\" (API key)."
+  default     = "bedrock"
+
+  validation {
+    condition     = contains(["bedrock", "openrouter"], var.chat_llm_kind)
+    error_message = "chat_llm_kind must be \"bedrock\" or \"openrouter\"."
+  }
+}
+
+variable "chat_llm_model" {
+  type        = string
+  description = "Model id for the chosen provider (e.g. a Bedrock model/inference-profile id, or an OpenRouter model)."
+
+  validation {
+    condition     = trimspace(var.chat_llm_model) != ""
+    error_message = "chat_llm_model must be set to the chosen provider's model id."
+  }
+}
+
+variable "chat_llm_api_key_ssm_parameter" {
+  type        = string
+  description = "SSM SecureString holding the OpenRouter API key. Required only when chat_llm_kind=openrouter; ignored for bedrock."
+  default     = ""
 }
 
 variable "booru_ssm_parameters" {
@@ -109,4 +132,35 @@ variable "budget_alert_emails" {
   type        = list(string)
   description = "Emails notified at 80% and 100% of monthly_budget_usd; required to enable the budget."
   default     = []
+}
+
+# --- Edge (Lightsail container service) ---------------------------------------
+
+variable "discord_token_ssm_parameter" {
+  type        = string
+  description = "SSM SecureString holding the edge's Discord bot token; injected into the container's environment."
+  default     = "/petbot/edge/discord_token"
+}
+
+variable "edge_power" {
+  type        = string
+  description = "Lightsail container service power. nano (0.25 vCPU/512MB) fits the edge; bump to micro if it OOMs."
+  default     = "nano"
+}
+
+variable "edge_scale" {
+  type        = number
+  description = "Number of container nodes (replicas). 1 always-on holder."
+  default     = 1
+}
+
+variable "edge_image" {
+  type        = string
+  description = <<-EOT
+    Image ref for the edge container, as returned by `aws lightsail
+    push-container-image` (e.g. ":petbot-edge.edge.1"). CI pushes the image and
+    passes this in; empty leaves the service with no deployment (apply the
+    service first, then push + set this — see README).
+  EOT
+  default     = ""
 }

--- a/docs/adr/0006-gateway-edge-microservice-skills.md
+++ b/docs/adr/0006-gateway-edge-microservice-skills.md
@@ -187,6 +187,45 @@ delete `interactions` → deploy bundles → LLM agent.
   #31 (gateway mode, Message Content on, no endpoint URL), #33 (music worker
   retained), #35 (dispatch-deferred), #30/#42/#38 (Lambda → compute tier).
 
+## Amendment (2026-06-18): edge host = Lightsail Container Service; cost-exit contingency
+
+§3 named "a small always-on box (Lightsail $5 instance)" as the holder. Refining
+that for the actual deploy:
+
+- **Holder = AWS Lightsail *Container Service* (`nano`), not a Lightsail
+  *instance*.** Same Lightsail cost class (~$7/mo flat, public IPv4 + data
+  bundled) but the **container service** is an immutable push-an-image target with
+  no box to patch and auto-restart on crash — the "dumb like a Lambda" property we
+  want. (A Lightsail instance is a pet VM: SSH, OS patching, manual restart.)
+  Measured edge footprint ≈ 76 MB RSS (discord.py + httpx + boto3), so `nano`
+  (512 MB) is ample; `micro` is the fallback.
+- **Edge → worker transport = boto3 `invoke` + IAM** (private; no public Function
+  URL, so no unauthenticated LLM-cost surface). Lightsail container services have
+  no IAM instance role, so the edge carries a **scoped IAM user** (`petbot-edge`,
+  `lambda:InvokeFunction` on the core worker only); its key is injected as env and
+  consumed by boto3's default credential chain (zero app code).
+- **Worker brain stays AWS Lambda** (arm64 image), with Bedrock access via the
+  exec role (or OpenRouter via an env key).
+
+**Cost-exit contingency (keep this open; no app change required).** The edge is a
+12-factor, outbound-only container; its sole external dependency is invoking one
+Lambda via boto3's default credential chain. So moving it is a provisioning swap,
+not a rewrite. If cost or control later warrant it:
+
+- The compute can move to a homelab Kubernetes cluster or a cheaper VPS, while
+  **AWS stays the public identity Discord sees** (the gateway is outbound, so the
+  edge's Discord traffic egresses through a small AWS node — Elastic IP +
+  WireGuard/forward-proxy — exactly this ADR's "homelab behind WireGuard; Discord
+  only ever sees the AWS holder's IP"). Only the Discord connection traverses AWS;
+  the worker-invoke and AWS-API calls go direct.
+- Keeping it **AWS-managed via hybrid** is possible: **IAM Roles Anywhere**
+  (X.509, no static key) gives an on-prem pod a real IAM role; **SSM hybrid
+  activations** register the box as an AWS-managed node. EKS Hybrid Nodes / ECS
+  Anywhere exist but are cost-disproportionate at this scale.
+- Guardrails preserved to keep the option free: env-only config, boto3 **default
+  credential chain** (env key today → instance/Roles-Anywhere role later, zero
+  code), and a registry-neutral OCI edge image.
+
 ## References
 
 - Builds on / supersedes: ADR 0005 (serverless deployment), ADR 0002 (deferred

--- a/src/petbot/workers/core/handler.py
+++ b/src/petbot/workers/core/handler.py
@@ -1,10 +1,13 @@
 """AWS Lambda handler for the core worker (the ``transport=lambda`` target).
 
-The edge invokes this Lambda with a dispatched-call JSON payload; the handler runs
-it and returns the :class:`~petbot.domain.result.SkillResult` JSON. The worker and
-its event loop are built once per cold start and reused across invocations — the
-loop must persist so skills' async clients (the booru ``httpx.AsyncClient``) stay
-bound to a live loop, exactly as the dev server does.
+The edge invokes this Lambda with a dispatched-call JSON payload (boto3
+``invoke``); the handler runs it and returns the
+:class:`~petbot.domain.result.SkillResult` as the response payload — verbatim,
+no HTTP envelope, because the edge's ``LambdaTransport`` reads the raw invoke
+``Payload`` straight into ``SkillResult.model_validate_json``. The worker and its
+event loop are built once per cold start and reused across invocations — the loop
+must persist so skills' async clients (the booru ``httpx.AsyncClient``) stay bound
+to a live loop, exactly as the dev server does.
 """
 
 from __future__ import annotations
@@ -35,11 +38,14 @@ def _get_loop() -> asyncio.AbstractEventLoop:
 
 
 def handler(event: dict[str, Any], context: object = None) -> dict[str, Any]:
-    """Lambda entrypoint: run the dispatched call, return its result as JSON.
+    """Lambda entrypoint: run the dispatched call, return the bare ``SkillResult``.
 
-    Accepts either a direct ``SkillCall`` payload (``boto3`` ``invoke``) or an API
-    Gateway-style event with a ``body`` string.
+    The event is the ``{"skill", "args", "context"}`` dispatch payload from the
+    edge's boto3 ``invoke`` (an API Gateway-style ``{"body": ...}`` wrapper is also
+    accepted). The return value becomes the invoke response ``Payload`` verbatim,
+    so it is the ``SkillResult`` itself — the edge parses it directly.
     """
     body = event["body"] if isinstance(event, dict) and "body" in event else json.dumps(event)
     out = _get_loop().run_until_complete(_get_worker().serve(body))
-    return {"statusCode": 200, "headers": {"content-type": "application/json"}, "body": out}
+    result: dict[str, Any] = json.loads(out)
+    return result

--- a/tests/workers/core/test_core.py
+++ b/tests/workers/core/test_core.py
@@ -13,9 +13,11 @@ def test_build_worker_hosts_all_core_skills() -> None:
     assert "music" not in names  # music is its own worker
 
 
-def test_handler_survives_repeated_warm_invocations() -> None:
-    # Regression for the persistent-loop fix: a second warm call must not hit a
-    # closed event loop. Math needs no network, so it exercises the loop reuse.
+def test_handler_returns_bare_skill_result_across_warm_invocations() -> None:
+    # The handler returns the SkillResult verbatim (no HTTP envelope) so the edge's
+    # LambdaTransport can parse the invoke Payload directly. Also a regression for
+    # the persistent-loop fix: a second warm call must not hit a closed event loop.
+    # Math needs no network, so it exercises both the contract and loop reuse.
     ctx = SkillContext(
         platform=Platform.DISCORD,
         user=User(platform=Platform.DISCORD, id="1", display_name="t"),
@@ -28,6 +30,6 @@ def test_handler_survives_repeated_warm_invocations() -> None:
     }
     for _ in range(2):
         response = handler(event)
-        assert response["statusCode"] == 200
-        result = SkillResult.model_validate_json(response["body"])
+        assert "statusCode" not in response  # bare result, not an API-Gateway envelope
+        result = SkillResult.model_validate(response)
         assert result.text is not None and "42" in result.text


### PR DESCRIPTION
Stacked on #53 — **base is `claude/petbot-a3a-2.1`**, so merging this lands the deploy rewrite *into* the #53 branch. Master only ever flips interactions→fully-migrated in one shot (merging #53 alone would auto-fire the stale `Deploy` on a half-migrated tree).

## Why
The `deploy/` stack still described the **deleted** serverless *interactions* design: a public Function-URL Lambda taking Discord webhooks, Ed25519 signature verification, and slash-command registration. #53 replaced that with **edge → worker**, so the deploy must follow: a **private core-worker Lambda** invoked by an **always-on edge**.

## What

**App (1 line + test)**
- `workers/core/handler.py` returns the **bare `SkillResult`** instead of an API-Gateway envelope, so the edge's `LambdaTransport` parses the boto3-invoke `Payload` directly.

**Core worker (Lambda)**
- Removed the Function URL, public invoke permission, and `DISCORD_PUBLIC_KEY` — the worker is **private**, invoked by the edge via **boto3 + IAM** (no public, unauthenticated LLM-cost surface).
- Chat-LLM config injected as nested env (`CHAT_LLM__KIND/MODEL[/API_KEY]`); **bedrock** gets a scoped `bedrock:InvokeModel` exec-role policy, **openrouter** reads its key from SSM. `timeout` 10→60.

**Edge (always-on gateway holder)**
- New **AWS Lightsail Container Service** (`nano`, amd64), env-configured, **no public endpoint** (outbound-only). Edge baseline measured ≈ 76 MB RSS; `micro` is the one-line fallback.
- A **scoped `petbot-edge` IAM user** whose only permission is `lambda:InvokeFunction` on the core worker; its access key is injected into the container env.
- **Image delivery = ECR-pull:** both images live in **ECR**; the Lightsail service pulls the edge image via private-registry access (an image-puller principal granted read on the edge repo in `edge.tf`). No `lightsailctl`, no image-ref scraping. *(This is the [official, IaC-supported path](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-container-service-ecr-private-repo-access.html); the lightsail-registry push is positioned for local-machine pushes.)*

**Stack / CI**
- One `name_prefix` derives `-core` / `-edge`; state key → `petbot/terraform.tfstate`; SSM → `/petbot/{core,edge}/*`. The old `petbot-interactions` stack is decommissioned once (documented).
- `deploy.yml`: build + push **both** images to ECR (worker arm64, edge amd64), then apply. **Non-secret config (chat kind/model, SSM param names, region) flows from GitHub Actions Variables → `TF_VAR_*`** (the required `chat_llm_model` previously had no path into the deploy). Secret values stay in SSM.
- **`images.yml`**: build-tests both Dockerfiles on every PR (no push, no AWS creds, native arch per image).
- `ci.yml`: dropped the vestigial `--all-packages`.

**Docs**
- `deploy/terraform/README.md` rewritten (ECR-pull flow + the **complete GitHub Variables checklist** needed for a green deploy); ADR 0006 amended.

## What you must provide for a running 2.1 (merging alone won't run it)
1. One-time **bootstrap** (CloudShell): `deploy/terraform/bootstrap` → state bucket + OIDC deploy role.
2. **SSM SecureStrings**: `/petbot/edge/discord_token`; if OpenRouter, `/petbot/core/openrouter_api_key`; optional booru creds.
3. **GitHub Actions Variables**: `DEPLOY_ROLE_ARN`, `AWS_REGION`, `TF_STATE_BUCKET`, `CHAT_LLM_KIND`, `CHAT_LLM_MODEL`, (`CHAT_LLM_API_KEY_SSM_PARAMETER` for OpenRouter). Full table in the README.

Then a push to `master` runs the deploy.

## Verification (local)
- `terraform fmt -check` + `validate` (root + bootstrap) ✅
- ruff · ruff format · mypy (strict, 66) · import-linter (4/4) · pytest (58) ✅
- Docker images build-tested in `images.yml` on this PR. The first real deploy is where the Lightsail puller-role activation and ECR-pull get exercised against live AWS.

## Known follow-ups
- One-time: `terraform destroy` the old `interactions/…` state.
- App (#53, separate): `LambdaTransport` could check boto3 `FunctionError` so a Lambda-level crash payload returns a clean error instead of mis-parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)