### PR TITLE
feat(chat): OpenAI-compatible provider for Bedrock mantle (Gemma 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,13 @@ WORKER__URL=http://127.0.0.1:8000/dispatch
 CHAT_LLM__KIND=openrouter
 CHAT_LLM__MODEL=google/gemma-3-27b-it:free
 CHAT_LLM__API_KEY=op://Private/PetBot/openrouter_api_key
-# bedrock (prod): just the model id (Bedrock does NOT host Gemma — e.g. Nova Lite).
+# openai_compatible (prod): any OpenAI-compatible endpoint by base URL + key —
+# e.g. Bedrock's Gemma 4 ("mantle" endpoint), or a self-hosted Ollama/vLLM.
+# CHAT_LLM__KIND=openai_compatible
+# CHAT_LLM__MODEL=google.gemma-4-26b-a4b
+# CHAT_LLM__BASE_URL=https://bedrock-mantle.us-east-1.api.aws/openai/v1
+# CHAT_LLM__API_KEY=op://Private/PetBot/bedrock_api_key
+# bedrock (Converse API + IAM, no key): Nova / Claude (NOT Gemma 4).
 # CHAT_LLM__KIND=bedrock
 # CHAT_LLM__MODEL=amazon.nova-lite-v1:0
 # Override the bot's persona (optional; a sensible default ships in code).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ env:
   TF_VAR_aws_region: ${{ vars.AWS_REGION }}
   TF_VAR_chat_llm_kind: ${{ vars.CHAT_LLM_KIND }}
   TF_VAR_chat_llm_model: ${{ vars.CHAT_LLM_MODEL }}
+  TF_VAR_chat_llm_base_url: ${{ vars.CHAT_LLM_BASE_URL }}
   TF_VAR_chat_llm_api_key_ssm_parameter: ${{ vars.CHAT_LLM_API_KEY_SSM_PARAMETER }}
 
 jobs:

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -49,8 +49,12 @@ scraping.
   aws ssm put-parameter --type SecureString \
     --name /petbot/edge/discord_token --value "<bot token>"
 
-  # Chat LLM: bedrock authenticates via the worker's IAM role (no secret).
-  # For openrouter instead, store the API key and set chat_llm_kind=openrouter:
+  # Chat LLM key — only for the key-based providers:
+  #   openai_compatible (e.g. Bedrock's Gemma 4 "mantle" endpoint): a Bedrock API
+  #   key (Bedrock console -> API keys). bedrock (Converse + IAM) needs no key.
+  # aws ssm put-parameter --type SecureString \
+  #   --name /petbot/core/bedrock_api_key --value "<bedrock api key>"
+  # openrouter instead:
   # aws ssm put-parameter --type SecureString \
   #   --name /petbot/core/openrouter_api_key --value "<key>"
 
@@ -84,9 +88,17 @@ referenced here only by parameter name). The deploy reads them as `TF_VAR_*`:
 | `DEPLOY_ROLE_ARN` | the deploy role ARN | `terraform -chdir=bootstrap output deploy_role_arn` |
 | `AWS_REGION` | e.g. `us-east-1` | your choice (match `backend.hcl` / SSM region) |
 | `TF_STATE_BUCKET` | the state bucket name | the `state_bucket` you chose above |
-| `CHAT_LLM_KIND` | `bedrock` or `openrouter` | your choice of provider |
-| `CHAT_LLM_MODEL` | the model id | a Bedrock model/inference-profile id, or an OpenRouter model id |
-| `CHAT_LLM_API_KEY_SSM_PARAMETER` | e.g. `/petbot/core/openrouter_api_key` | **only** for `openrouter`; leave unset for `bedrock` |
+| `CHAT_LLM_KIND` | `bedrock` \| `openai_compatible` \| `openrouter` | your choice of provider |
+| `CHAT_LLM_MODEL` | the model id | e.g. `google.gemma-4-26b-a4b` (Gemma 4 via mantle), a Bedrock Converse model, or an OpenRouter model |
+| `CHAT_LLM_BASE_URL` | endpoint URL | **only** for `openai_compatible`, e.g. `https://bedrock-mantle.us-east-1.api.aws/openai/v1`; unset otherwise |
+| `CHAT_LLM_API_KEY_SSM_PARAMETER` | e.g. `/petbot/core/bedrock_api_key` | for `openai_compatible` + `openrouter`; **unset** for `bedrock` |
+
+**Provider notes.** `bedrock` = the Converse API with IAM auth (no key) — Nova /
+Claude. **Gemma 4 is served only via Bedrock's OpenAI-compatible "mantle"
+endpoint**, so for Gemma 4 use `CHAT_LLM_KIND=openai_compatible` with the
+`CHAT_LLM_BASE_URL` above and a **Bedrock API key** in SSM. The same
+`openai_compatible` kind also points at a self-hosted Ollama/vLLM later — just a
+different base URL.
 
 That's the complete list — once these Variables and the SSM secrets above exist,
 a push to `master` runs a green deploy. (Merging the PR alone does **not** create

--- a/deploy/terraform/secrets.tf
+++ b/deploy/terraform/secrets.tf
@@ -8,19 +8,24 @@
 # Keeping state fully secret-free would require the function to fetch SSM at
 # runtime instead — a documented future hardening (tracked with secrets/ops #17).
 
-# OpenRouter API key — only when that provider is selected. Bedrock authenticates
-# with the exec role's IAM policy (main.tf), so it needs no secret here.
+locals {
+  # Both key-based providers carry the chat API key (an OpenRouter key, or a
+  # Bedrock API key for the openai_compatible "mantle" endpoint). Plain bedrock
+  # (Converse + IAM) needs no key.
+  chat_needs_api_key = contains(["openrouter", "openai_compatible"], var.chat_llm_kind)
+}
+
 data "aws_ssm_parameter" "chat_api_key" {
-  count           = var.chat_llm_kind == "openrouter" ? 1 : 0
+  count           = local.chat_needs_api_key ? 1 : 0
   name            = var.chat_llm_api_key_ssm_parameter
   with_decryption = true
 
   # Fail at plan with a clear message instead of an opaque "name is required"
-  # SSM error when the param name was left empty for the openrouter provider.
+  # SSM error when the param name was left empty for a key-based provider.
   lifecycle {
     precondition {
       condition     = trimspace(var.chat_llm_api_key_ssm_parameter) != ""
-      error_message = "chat_llm_kind=openrouter requires chat_llm_api_key_ssm_parameter (the SSM SecureString holding the key)."
+      error_message = "chat_llm_kind=${var.chat_llm_kind} requires chat_llm_api_key_ssm_parameter (the SSM SecureString holding the key)."
     }
   }
 }
@@ -37,15 +42,16 @@ locals {
       ENV       = var.lambda_environment
       LOG_LEVEL = var.log_level
       # The chat agent's provider config, as the nested env the worker's
-      # ChatSettings reads (CHAT_LLM__KIND / CHAT_LLM__MODEL[ / __API_KEY]).
+      # ChatSettings reads (CHAT_LLM__KIND / CHAT_LLM__MODEL[ / __BASE_URL / __API_KEY]).
       CHAT_LLM__KIND  = var.chat_llm_kind
       CHAT_LLM__MODEL = var.chat_llm_model
     },
+    var.chat_llm_base_url != "" ? { CHAT_LLM__BASE_URL = var.chat_llm_base_url } : {},
     var.user_agent != "" ? { USER_AGENT = var.user_agent } : {},
   )
 
   secret_env = merge(
-    var.chat_llm_kind == "openrouter" ? { CHAT_LLM__API_KEY = data.aws_ssm_parameter.chat_api_key[0].value } : {},
+    local.chat_needs_api_key ? { CHAT_LLM__API_KEY = data.aws_ssm_parameter.chat_api_key[0].value } : {},
     { for env_name, param in data.aws_ssm_parameter.booru : env_name => param.value },
   )
 

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -11,11 +11,16 @@ lambda_environment = "prod"
 log_level          = "INFO"
 
 # --- Chat LLM (the core worker's agent) ---
-# bedrock authenticates via the exec role's IAM (no secret); openrouter needs a key.
-chat_llm_kind  = "bedrock"
-chat_llm_model = "" # REQUIRED — set to a Bedrock model/inference-profile id, or an OpenRouter model id
-# Only for openrouter: SSM SecureString holding the API key.
-# chat_llm_api_key_ssm_parameter = "/petbot/core/openrouter_api_key"
+# bedrock: Converse API + IAM (no key), e.g. Nova / Claude.
+# openai_compatible: any OpenAI-compatible endpoint + key — incl. Bedrock's
+#   Gemma 4 "mantle" endpoint, or a self-hosted Ollama/vLLM.
+# openrouter: OpenRouter + key.
+chat_llm_kind  = "openai_compatible"
+chat_llm_model = "" # REQUIRED — e.g. google.gemma-4-26b-a4b
+# Required for openai_compatible (the endpoint URL):
+# chat_llm_base_url = "https://bedrock-mantle.us-east-1.api.aws/openai/v1"
+# Required for openai_compatible + openrouter (SSM SecureString holding the key):
+# chat_llm_api_key_ssm_parameter = "/petbot/core/bedrock_api_key"
 
 # Optional booru auth: ENV-VAR-NAME => SSM-parameter-name.
 # booru_ssm_parameters = {

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -67,13 +67,25 @@ variable "timeout" {
 
 variable "chat_llm_kind" {
   type        = string
-  description = "Chat provider discriminator: \"bedrock\" (IAM-auth) or \"openrouter\" (API key)."
+  description = <<-EOT
+    Chat provider discriminator:
+      bedrock           - Converse API, IAM-auth, no key (Nova / Claude).
+      openai_compatible - any OpenAI-compatible endpoint by base URL + key
+                          (Bedrock's Gemma 4 "mantle" endpoint, or Ollama/vLLM).
+      openrouter        - OpenRouter (API key).
+  EOT
   default     = "bedrock"
 
   validation {
-    condition     = contains(["bedrock", "openrouter"], var.chat_llm_kind)
-    error_message = "chat_llm_kind must be \"bedrock\" or \"openrouter\"."
+    condition     = contains(["bedrock", "openai_compatible", "openrouter"], var.chat_llm_kind)
+    error_message = "chat_llm_kind must be one of: bedrock, openai_compatible, openrouter."
   }
+}
+
+variable "chat_llm_base_url" {
+  type        = string
+  description = "Base URL for the openai_compatible provider, e.g. https://bedrock-mantle.<region>.api.aws/openai/v1. Required for that kind; ignored otherwise."
+  default     = ""
 }
 
 variable "chat_llm_model" {
@@ -88,7 +100,7 @@ variable "chat_llm_model" {
 
 variable "chat_llm_api_key_ssm_parameter" {
   type        = string
-  description = "SSM SecureString holding the OpenRouter API key. Required only when chat_llm_kind=openrouter; ignored for bedrock."
+  description = "SSM SecureString holding the chat API key (OpenRouter key, or a Bedrock API key for openai_compatible). Required for openrouter + openai_compatible; ignored for bedrock."
   default     = ""
 }
 

--- a/docs/adr/0006-gateway-edge-microservice-skills.md
+++ b/docs/adr/0006-gateway-edge-microservice-skills.md
@@ -84,6 +84,12 @@ is consolidated** until scale justifies splitting:
   native tool calling, in-boundary for privacy, ~cents–low-$/mo at this scale.
   **OpenRouter (free Gemma 4)** is the dev/low-volume adapter. The model is the
   same across both, so the provider is a config flip.
+- Implementation note (2026-06): on Bedrock, **Gemma 4 is served only via the
+  OpenAI-compatible `bedrock-mantle` endpoint** (`https://bedrock-mantle.<region>.api.aws/openai/v1`,
+  Bedrock API key), *not* the Converse API. So the config has three `CHAT_LLM__KIND`
+  variants: `bedrock` (Converse + IAM: Nova/Claude), `openai_compatible` (base URL
+  + key: Gemma 4 mantle today, a self-hosted Ollama/vLLM later), and `openrouter`.
+  Gemma 4 prod uses `openai_compatible`.
 
 ### 5. Repository structure — uv workspace, hexagonal
 

--- a/src/petbot/skills/chat/model.py
+++ b/src/petbot/skills/chat/model.py
@@ -10,7 +10,12 @@ from typing import assert_never
 
 from pydantic_ai.models import Model
 
-from petbot.skills.chat.settings import BedrockModel, ChatSettings, OpenRouterModel
+from petbot.skills.chat.settings import (
+    BedrockModel,
+    ChatSettings,
+    OpenAICompatibleModel,
+    OpenRouterModel,
+)
 
 
 def build_model(settings: ChatSettings) -> Model:
@@ -21,6 +26,13 @@ def build_model(settings: ChatSettings) -> Model:
             from pydantic_ai.providers.openrouter import OpenRouterProvider
 
             return OpenAIChatModel(model, provider=OpenRouterProvider(api_key=api_key))
+        case OpenAICompatibleModel(model=model, base_url=base_url, api_key=api_key):
+            from pydantic_ai.models.openai import OpenAIChatModel
+            from pydantic_ai.providers.openai import OpenAIProvider
+
+            return OpenAIChatModel(
+                model, provider=OpenAIProvider(base_url=base_url, api_key=api_key)
+            )
         case BedrockModel(model=model):
             from pydantic_ai.models.bedrock import BedrockConverseModel
 

--- a/src/petbot/skills/chat/settings.py
+++ b/src/petbot/skills/chat/settings.py
@@ -38,8 +38,25 @@ class OpenRouterModel(BaseModel):
     api_key: str
 
 
+class OpenAICompatibleModel(BaseModel):
+    """Any OpenAI-compatible chat endpoint, reached by base URL + API key.
+
+    Covers AWS Bedrock's OpenAI-compatible ``bedrock-mantle`` endpoint (how Gemma 4
+    is served — ``base_url=https://bedrock-mantle.<region>.api.aws/openai/v1``,
+    ``api_key`` = a Bedrock API key), and equally a self-hosted Ollama/vLLM. The
+    provider is just a URL + key, so new backends are config, not code.
+    """
+
+    kind: Literal["openai_compatible"] = "openai_compatible"
+    model: str
+    base_url: str
+    api_key: str
+
+
 #: Exactly one provider config, with only its own fields. Tagged by ``kind``.
-LLMConfig = Annotated[BedrockModel | OpenRouterModel, Field(discriminator="kind")]
+LLMConfig = Annotated[
+    BedrockModel | OpenRouterModel | OpenAICompatibleModel, Field(discriminator="kind")
+]
 
 
 class ChatSettings(BaseSettings):

--- a/tests/skills/chat/test_chat.py
+++ b/tests/skills/chat/test_chat.py
@@ -9,7 +9,8 @@ from pydantic_ai.models.test import TestModel
 
 from petbot.domain import EmbedSpec, Platform, SkillContext, SkillResult, User
 from petbot.skills.chat import ChatSkill
-from petbot.skills.chat.settings import ChatSettings, OpenRouterModel
+from petbot.skills.chat.model import build_model
+from petbot.skills.chat.settings import ChatSettings, OpenAICompatibleModel, OpenRouterModel
 from petbot.types import BooruArgs, ChatArgs, MathArgs, MusicArgs
 
 
@@ -25,6 +26,28 @@ def test_openrouter_variant_requires_api_key() -> None:
     # The OpenRouter variant has api_key as a required field — no conditional None.
     with pytest.raises(ValidationError):
         OpenRouterModel(model="x")  # type: ignore[call-arg]  # missing api_key is the point
+
+
+def test_openai_compatible_variant_requires_base_url_and_key() -> None:
+    # base_url + api_key are required fields of this variant (no conditional None).
+    with pytest.raises(ValidationError):
+        OpenAICompatibleModel(model="x")  # type: ignore[call-arg]
+
+
+def test_openai_compatible_builds_an_openai_model() -> None:
+    # The Bedrock-mantle / Ollama path: build_model wires an OpenAI-compatible
+    # client to the given base URL. Construction is offline (no network).
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+    settings = ChatSettings(
+        llm=OpenAICompatibleModel(
+            model="google.gemma-4-26b-a4b",
+            base_url="https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+            api_key="test-key",
+        ),
+        _env_file=None,
+    )
+    assert isinstance(build_model(settings), OpenAIChatModel)
 
 
 class FakeSkills:


### PR DESCRIPTION
Stacked on #53 (base `claude/petbot-a3a-2.1`) — needed **before** merging #53 if prod chat is Gemma 4.

## Why
ADR 0006 §4 sets prod chat = **Gemma 4 on Bedrock**. But [Bedrock serves Gemma 4 **only** via its OpenAI-compatible `bedrock-mantle` endpoint](https://aws.amazon.com/blogs/machine-learning/introducing-gemma-4-models-on-amazon-bedrock/) (bearer **Bedrock API key**), **not** the Converse API our `bedrock` kind uses. So `CHAT_LLM_KIND=bedrock` + a Gemma 4 id would deploy green but fail at first chat. This adds the missing path.

## What
- **New `openai_compatible` LLM variant** (generic: `model` + `base_url` + `api_key`). `build_model` wires `OpenAIChatModel(model, provider=OpenAIProvider(base_url, api_key))`. Serves Gemma 4 via the mantle URL today, and a self-hosted **Ollama/vLLM** later with just a different URL — config, not code. The discriminated union stays exhaustive (`assert_never`).
- The existing `bedrock` (Converse + IAM, no key — Nova/Claude) and `openrouter` kinds are unchanged.
- **Deploy wiring:** `chat_llm_kind` gains `openai_compatible`; new `chat_llm_base_url` var; the chat API key + base URL are injected for `openrouter`/`openai_compatible` (bedrock stays keyless via IAM). `deploy.yml` passes `CHAT_LLM_BASE_URL` from a GitHub Variable.
- **Docs:** README provider table + the Bedrock-API-key SSM param; `.env.example`; ADR 0006 §4 records the mantle endpoint + the three kinds.

## To run Gemma 4 in prod
- SSM: `/petbot/core/bedrock_api_key` (a Bedrock API key — Bedrock console → API keys).
- GitHub Variables: `CHAT_LLM_KIND=openai_compatible`, `CHAT_LLM_MODEL=google.gemma-4-26b-a4b`, `CHAT_LLM_BASE_URL=https://bedrock-mantle.us-east-1.api.aws/openai/v1`, `CHAT_LLM_API_KEY_SSM_PARAMETER=/petbot/core/bedrock_api_key`.

## Verification (local)
- ruff · ruff format · mypy (strict, 66) · import-linter (4/4) · **pytest 60** (+2 new chat tests) ✅
- `terraform fmt -check` + `validate` ✅
- Model construction is offline; the live mantle call is first exercised on a real deploy.

## Not included (you picked single-model, not tiering)
Tiered routing (Gemma 4 E2B for simple / 26B for complex) would be a follow-up — the `openai_compatible` variant makes adding a second model + a router straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018AE3E1MRysoTBHxgQhH1rA)_