### PR TITLE
feat(deploy): Fargate as a swappable edge host (EDGE_HOST)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ env:
   # Non-secret deploy config, supplied as GitHub Actions Variables and read by
   # Terraform as TF_VAR_* (secret *values* stay in SSM, referenced by name).
   TF_VAR_aws_region: ${{ vars.AWS_REGION }}
+  # Edge host: "lightsail" (default) or "fargate". Unset => lightsail.
+  TF_VAR_edge_host: ${{ vars.EDGE_HOST || 'lightsail' }}
   TF_VAR_chat_llm_kind: ${{ vars.CHAT_LLM_KIND }}
   TF_VAR_chat_llm_model: ${{ vars.CHAT_LLM_MODEL }}
   TF_VAR_chat_llm_base_url: ${{ vars.CHAT_LLM_BASE_URL }}
@@ -124,4 +126,5 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform output -raw core_function_arn; echo
-          terraform output -raw edge_container_service_name; echo
+          terraform output -raw edge_host; echo
+          terraform output -raw edge_service_name; echo

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -37,6 +37,21 @@ auto-created "image puller" principal that `edge.tf` grants read on the edge
 repo). One registry, one push mechanism — no `lightsailctl`, no image-ref
 scraping.
 
+### Edge host: `lightsail` or `fargate`
+
+`EDGE_HOST` selects where the edge runs, **swappable at any time** (flip the
+Variable, re-run Deploy):
+
+- **`lightsail`** (default) — a Lightsail container service. Flat ~$7/mo, IPv4
+  bundled, immutable push. *Caveat:* new accounts can have a **0 quota** for
+  container services (needs an AWS Support case to raise).
+- **`fargate`** — an ECS Fargate service in the default VPC (`edge_fargate.tf`).
+  No Lightsail quota; the task uses an **IAM task role** (no static key) and ECS
+  fetches the token from SSM at launch. ~$11/mo (compute + a public IPv4).
+
+Both run the same amd64 edge image from the same ECR repo. The unused host's
+resources simply aren't created (`count = 0`).
+
 ## Prerequisites
 
 - An AWS account with credentials in your shell (e.g. `aws sso login`).
@@ -88,6 +103,7 @@ referenced here only by parameter name). The deploy reads them as `TF_VAR_*`:
 | `DEPLOY_ROLE_ARN` | the deploy role ARN | `terraform -chdir=bootstrap output deploy_role_arn` |
 | `AWS_REGION` | e.g. `us-east-1` | your choice (match `backend.hcl` / SSM region) |
 | `TF_STATE_BUCKET` | the state bucket name | the `state_bucket` you chose above |
+| `EDGE_HOST` | `lightsail` (default) \| `fargate` | where the edge runs — swappable any time |
 | `CHAT_LLM_KIND` | `bedrock` \| `openai_compatible` \| `openrouter` | your choice of provider |
 | `CHAT_LLM_MODEL` | the model id | e.g. `google.gemma-4-26b-a4b` (Gemma 4 via mantle), a Bedrock Converse model, or an OpenRouter model |
 | `CHAT_LLM_BASE_URL` | endpoint URL | **only** for `openai_compatible`, e.g. `https://bedrock-mantle.us-east-1.api.aws/openai/v1`; unset otherwise |

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -301,6 +301,19 @@ data "aws_iam_policy_document" "deploy_permissions" {
     resources = ["*"]
   }
 
+  # First ECS use in an account needs the AWSServiceRoleForECS service-linked
+  # role; ECS auto-creates it iff the caller can. Fenced to the ECS service.
+  statement {
+    sid       = "EcsServiceLinkedRole"
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["arn:aws:iam::${local.account_id}:role/aws-service-role/ecs.amazonaws.com/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["ecs.amazonaws.com"]
+    }
+  }
+
   # Read the default VPC/subnets and manage the edge's egress security group.
   # Describe* and SG creation have no scopable resource ARN at plan time.
   statement {

--- a/deploy/terraform/bootstrap/main.tf
+++ b/deploy/terraform/bootstrap/main.tf
@@ -137,6 +137,13 @@ locals {
   log_group_arn     = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/aws/lambda/${local.core_name}"
   exec_role_arn     = "arn:aws:iam::${local.account_id}:role/${local.core_name}-role"
   edge_user_arn     = "arn:aws:iam::${local.account_id}:user/${local.edge_name}"
+
+  # Fargate host option (edge_host = "fargate"): the ECS log group and the two
+  # task roles this stack owns.
+  edge_log_group_arn  = "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/${local.edge_name}"
+  edge_exec_role_arn  = "arn:aws:iam::${local.account_id}:role/${local.edge_name}-exec"
+  edge_task_role_arn  = "arn:aws:iam::${local.account_id}:role/${local.edge_name}-task"
+  edge_task_role_arns = [local.edge_exec_role_arn, local.edge_task_role_arn]
 }
 
 # Least-privilege permissions for the deploy workflow. Service-level action
@@ -192,9 +199,12 @@ data "aws_iam_policy_document" "deploy_permissions" {
   }
 
   statement {
-    sid       = "ManageLogs"
-    actions   = ["logs:*"]
-    resources = [local.log_group_arn, "${local.log_group_arn}:*"]
+    sid     = "ManageLogs"
+    actions = ["logs:*"]
+    resources = [
+      local.log_group_arn, "${local.log_group_arn}:*",
+      local.edge_log_group_arn, "${local.edge_log_group_arn}:*",
+    ]
   }
 
   # logs:DescribeLogGroups is a list operation that AWS only authorizes on "*"
@@ -277,6 +287,71 @@ data "aws_iam_policy_document" "deploy_permissions" {
       "iam:ListAttachedUserPolicies",
     ]
     resources = [local.edge_user_arn]
+  }
+
+  # --- Fargate host option (edge_host = "fargate") ----------------------------
+
+  # ECS cluster/service/task-definition management. Many ECS actions (Register/
+  # DescribeTaskDefinition, list/describe) are not resource-scopable, so this is a
+  # service-level grant — same rationale as lightsail:* above; the account's ECS
+  # holds only this edge.
+  statement {
+    sid       = "ManageEcs"
+    actions   = ["ecs:*"]
+    resources = ["*"]
+  }
+
+  # Read the default VPC/subnets and manage the edge's egress security group.
+  # Describe* and SG creation have no scopable resource ARN at plan time.
+  statement {
+    sid = "EdgeNetworking"
+    actions = [
+      "ec2:DescribeVpcs",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSecurityGroupRules",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:CreateSecurityGroup",
+      "ec2:DeleteSecurityGroup",
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+    ]
+    resources = ["*"]
+  }
+
+  # Create/manage only the two Fargate task roles this stack owns (exec + task).
+  statement {
+    sid = "ManageEdgeTaskRoles"
+    actions = [
+      "iam:GetRole",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:GetRolePolicy",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:TagRole",
+      "iam:UntagRole",
+    ]
+    resources = local.edge_task_role_arns
+  }
+
+  # Pass the task roles only to ECS tasks (fenced like the Lambda exec role).
+  statement {
+    sid       = "PassEdgeTaskRolesToEcs"
+    actions   = ["iam:PassRole"]
+    resources = local.edge_task_role_arns
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 

--- a/deploy/terraform/edge.tf
+++ b/deploy/terraform/edge.tf
@@ -1,37 +1,13 @@
-# --- The always-on edge: a Lightsail container service ------------------------
+# --- The edge's ECR repository (shared by both host options) -------------------
 #
 # The edge holds the Discord gateway (an outbound WebSocket) and dispatches each
-# @mention to the core worker Lambda. Lightsail container service is the host:
-# flat-rate, public IPv4 + data bundled, immutable container push (no box to
-# patch). It serves no HTTP — it only dials out to Discord and to the worker — so
-# the deployment configures NO public endpoint. Lightsail supports this: the
-# container still runs, reachable only on the private `<name>.service.local`
-# domain (which the edge never needs), and no health-check port is required.
-#
-# Image delivery is ECR-pull: the edge image lives in its own ECR repo (the same
-# registry the worker uses), and the service pulls it via an "image puller" IAM
-# role (the declarative equivalent of what the Lightsail console wires up). The
-# image must be linux/amd64 (Lightsail container services are amd64-only; an
-# arm64 image fails with "exec format error") — see Dockerfile.edge. Measured edge
-# footprint ~76 MB RSS, so `nano` (512 MB) is ample; bump var.edge_power to
-# `micro` if it ever OOMs.
+# @mention to the core worker Lambda. Where it RUNS is var.edge_host:
+#   lightsail - a Lightsail container service (this file). Flat-rate, IPv4
+#               bundled, immutable push; but new accounts can have a 0 quota.
+#   fargate   - an ECS Fargate service (edge_fargate.tf). No Lightsail quota; the
+#               task gets an IAM role (no static key).
+# Both pull the same amd64 edge image from this ECR repo.
 
-resource "aws_lightsail_container_service" "edge" {
-  name  = local.edge_name
-  power = var.edge_power
-  scale = var.edge_scale
-
-  # Activating this creates an AWS-managed ECR "image puller" principal for the
-  # service; we grant it read on the edge repo below. (Same-Region requirement:
-  # the repo and the service are both in var.aws_region.)
-  private_registry_access {
-    ecr_image_puller_role {
-      is_active = true
-    }
-  }
-}
-
-# The edge's own ECR repository.
 resource "aws_ecr_repository" "edge" {
   name                 = local.edge_name
   image_tag_mutability = "MUTABLE"
@@ -42,11 +18,36 @@ resource "aws_ecr_repository" "edge" {
   }
 }
 
-# Grant the service's puller principal read access on the edge repo — exactly the
-# statement the Lightsail console would add for you, here as code. The principal
-# ARN is populated once the puller role is active; Terraform orders this after the
-# service create because it references that attribute.
+# The Discord token's SSM parameter ARN — both hosts reference it (Lightsail reads
+# the value into env; Fargate hands the ARN to ECS to fetch at task launch).
+locals {
+  discord_token_arn = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${var.discord_token_ssm_parameter}"
+}
+
+# --- Lightsail host (var.edge_host == "lightsail") ----------------------------
+# Serves no HTTP (no public_endpoint); the container runs reachable only on the
+# private domain it never needs. Image is linux/amd64 (Lightsail is amd64-only).
+# Pulls from ECR via an "image puller" principal granted read on the repo.
+
+locals {
+  on_lightsail = var.edge_host == "lightsail"
+}
+
+resource "aws_lightsail_container_service" "edge" {
+  count = local.on_lightsail ? 1 : 0
+  name  = local.edge_name
+  power = var.edge_power
+  scale = var.edge_scale
+
+  private_registry_access {
+    ecr_image_puller_role {
+      is_active = true
+    }
+  }
+}
+
 resource "aws_ecr_repository_policy" "edge" {
+  count      = local.on_lightsail ? 1 : 0
   repository = aws_ecr_repository.edge.name
 
   policy = jsonencode({
@@ -54,19 +55,16 @@ resource "aws_ecr_repository_policy" "edge" {
     Statement = [{
       Sid       = "AllowLightsailPull"
       Effect    = "Allow"
-      Principal = { AWS = aws_lightsail_container_service.edge.private_registry_access[0].ecr_image_puller_role[0].principal_arn }
+      Principal = { AWS = aws_lightsail_container_service.edge[0].private_registry_access[0].ecr_image_puller_role[0].principal_arn }
       Action    = ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"]
     }]
   })
 }
 
-# The container deployment. Skipped until an image tag is supplied (CI pushes the
-# image to ECR, then passes its tag), so the service + puller can be created
-# first. Lightsail pulls from ECR using the puller role, so the repo policy must
-# exist before the deployment is created.
+# The deployment — only once an image tag is supplied (CI pushes, then passes it).
 resource "aws_lightsail_container_service_deployment_version" "edge" {
-  count        = var.edge_image_tag != "" ? 1 : 0
-  service_name = aws_lightsail_container_service.edge.name
+  count        = local.on_lightsail && var.edge_image_tag != "" ? 1 : 0
+  service_name = aws_lightsail_container_service.edge[0].name
 
   container {
     container_name = "edge"
@@ -78,11 +76,11 @@ resource "aws_lightsail_container_service_deployment_version" "edge" {
       WORKER__KIND          = "lambda"
       WORKER__FUNCTION_NAME = aws_lambda_function.this.function_name
       AWS_REGION            = var.aws_region
-      # Scoped identity for boto3's default credential chain (Lightsail container
-      # services have no IAM instance roles, so a static key is the mechanism).
-      AWS_ACCESS_KEY_ID     = aws_iam_access_key.edge.id
-      AWS_SECRET_ACCESS_KEY = aws_iam_access_key.edge.secret
-      DISCORD_TOKEN         = data.aws_ssm_parameter.discord_token.value
+      # Lightsail has no IAM instance role, so a scoped static key is the
+      # mechanism; boto3's default credential chain reads it.
+      AWS_ACCESS_KEY_ID     = aws_iam_access_key.edge[0].id
+      AWS_SECRET_ACCESS_KEY = aws_iam_access_key.edge[0].secret
+      DISCORD_TOKEN         = data.aws_ssm_parameter.discord_token[0].value
     }
   }
 
@@ -90,24 +88,26 @@ resource "aws_lightsail_container_service_deployment_version" "edge" {
 }
 
 data "aws_ssm_parameter" "discord_token" {
+  count           = local.on_lightsail ? 1 : 0
   name            = var.discord_token_ssm_parameter
   with_decryption = true
 }
 
-# --- The edge's scoped AWS identity -------------------------------------------
-# Least privilege: invoke exactly the core worker Lambda, nothing else.
-
+# The Lightsail edge's scoped AWS identity (Fargate uses a task role instead).
 resource "aws_iam_user" "edge" {
-  name = local.edge_name
+  count = local.on_lightsail ? 1 : 0
+  name  = local.edge_name
 }
 
 resource "aws_iam_access_key" "edge" {
-  user = aws_iam_user.edge.name
+  count = local.on_lightsail ? 1 : 0
+  user  = aws_iam_user.edge[0].name
 }
 
 resource "aws_iam_user_policy" "edge_invoke" {
-  name = "${local.edge_name}-invoke-core"
-  user = aws_iam_user.edge.name
+  count = local.on_lightsail ? 1 : 0
+  name  = "${local.edge_name}-invoke-core"
+  user  = aws_iam_user.edge[0].name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/deploy/terraform/edge_fargate.tf
+++ b/deploy/terraform/edge_fargate.tf
@@ -1,0 +1,173 @@
+# --- Fargate host (var.edge_host == "fargate") --------------------------------
+#
+# An ECS Fargate service runs the edge container. No Lightsail quota; the task
+# carries an IAM *task role* (so the edge invokes the worker Lambda without any
+# static key — cleaner than the Lightsail path). Outbound-only: a public IP for
+# IPv4 egress to Discord + AWS, an egress-all security group, no inbound. The
+# Discord token is fetched by ECS from SSM at task launch (never in TF state).
+
+locals {
+  on_fargate = var.edge_host == "fargate"
+}
+
+# Run in the account's default VPC so no networking has to be built.
+data "aws_vpc" "default" {
+  count   = local.on_fargate ? 1 : 0
+  default = true
+}
+
+data "aws_subnets" "default" {
+  count = local.on_fargate ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default[0].id]
+  }
+}
+
+resource "aws_security_group" "edge" {
+  count       = local.on_fargate ? 1 : 0
+  name        = "${local.edge_name}-egress"
+  description = "Edge task: outbound only (Discord gateway + AWS APIs)."
+  vpc_id      = data.aws_vpc.default[0].id
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "edge" {
+  count             = local.on_fargate ? 1 : 0
+  name              = "/ecs/${local.edge_name}"
+  retention_in_days = var.log_retention_days
+}
+
+# --- Task roles ---------------------------------------------------------------
+
+data "aws_iam_policy_document" "ecs_assume" {
+  count = local.on_fargate ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# Execution role: ECS itself uses it to pull the image + write logs + read the
+# token secret. (Distinct from the task role the app runs as.)
+resource "aws_iam_role" "edge_exec" {
+  count              = local.on_fargate ? 1 : 0
+  name               = "${local.edge_name}-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "edge_exec" {
+  count      = local.on_fargate ? 1 : 0
+  role       = aws_iam_role.edge_exec[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "edge_exec_secrets" {
+  count = local.on_fargate ? 1 : 0
+  name  = "read-discord-token"
+  role  = aws_iam_role.edge_exec[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameters"]
+      Resource = [local.discord_token_arn]
+    }]
+  })
+}
+
+# Task role: the edge's runtime identity — invoke exactly the worker Lambda.
+resource "aws_iam_role" "edge_task" {
+  count              = local.on_fargate ? 1 : 0
+  name               = "${local.edge_name}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume[0].json
+}
+
+resource "aws_iam_role_policy" "edge_task_invoke" {
+  count = local.on_fargate ? 1 : 0
+  name  = "invoke-core"
+  role  = aws_iam_role.edge_task[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "lambda:InvokeFunction"
+      Resource = aws_lambda_function.this.arn
+    }]
+  })
+}
+
+# --- Cluster, task, service ---------------------------------------------------
+
+resource "aws_ecs_cluster" "edge" {
+  count = local.on_fargate ? 1 : 0
+  name  = local.edge_name
+}
+
+# Task + service need the image; created once CI has pushed it (edge_image_tag).
+resource "aws_ecs_task_definition" "edge" {
+  count                    = local.on_fargate && var.edge_image_tag != "" ? 1 : 0
+  family                   = local.edge_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.edge_cpu
+  memory                   = var.edge_memory
+  execution_role_arn       = aws_iam_role.edge_exec[0].arn
+  task_role_arn            = aws_iam_role.edge_task[0].arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64" # the edge image is amd64 (see Dockerfile.edge)
+  }
+
+  container_definitions = jsonencode([{
+    name      = "edge"
+    image     = "${aws_ecr_repository.edge.repository_url}:${var.edge_image_tag}"
+    essential = true
+    environment = [
+      { name = "LOG_LEVEL", value = var.log_level },
+      { name = "ENV", value = var.lambda_environment },
+      { name = "WORKER__KIND", value = "lambda" },
+      { name = "WORKER__FUNCTION_NAME", value = aws_lambda_function.this.function_name },
+      { name = "AWS_REGION", value = var.aws_region },
+    ]
+    secrets = [
+      { name = "DISCORD_TOKEN", valueFrom = local.discord_token_arn },
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.edge[0].name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "edge"
+      }
+    }
+  }])
+}
+
+resource "aws_ecs_service" "edge" {
+  count           = local.on_fargate && var.edge_image_tag != "" ? 1 : 0
+  name            = local.edge_name
+  cluster         = aws_ecs_cluster.edge[0].id
+  task_definition = aws_ecs_task_definition.edge[0].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.default[0].ids
+    security_groups  = [aws_security_group.edge[0].id]
+    assign_public_ip = true # gives the task a routable IPv4 for the Discord gateway
+  }
+}

--- a/deploy/terraform/edge_fargate.tf
+++ b/deploy/terraform/edge_fargate.tf
@@ -79,11 +79,24 @@ resource "aws_iam_role_policy" "edge_exec_secrets" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["ssm:GetParameters"]
-      Resource = [local.discord_token_arn]
-    }]
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:GetParameters"]
+        Resource = [local.discord_token_arn]
+      },
+      # The token is a SecureString, so ECS must kms:Decrypt it. Scoped via
+      # kms:ViaService so this role can only decrypt through SSM (incl. the
+      # AWS-managed aws/ssm key, whose policy defers to IAM).
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = "*"
+        Condition = {
+          StringEquals = { "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com" }
+        }
+      },
+    ]
   })
 }
 

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -14,11 +14,20 @@ output "ecr_repository_url" {
 }
 
 output "edge_ecr_repository_url" {
-  description = "Push the edge image here; the Lightsail service pulls it from this repo."
+  description = "Push the edge image here; the host (Lightsail or Fargate) pulls it from this repo."
   value       = aws_ecr_repository.edge.repository_url
 }
 
-output "edge_container_service_name" {
-  description = "Lightsail container service hosting the edge."
-  value       = aws_lightsail_container_service.edge.name
+output "edge_host" {
+  description = "Where the edge runs: lightsail or fargate."
+  value       = var.edge_host
+}
+
+output "edge_service_name" {
+  description = "Name of the edge service on whichever host is active (empty until an image is deployed)."
+  value = (
+    var.edge_host == "lightsail"
+    ? try(aws_lightsail_container_service.edge[0].name, "")
+    : try(aws_ecs_service.edge[0].name, "")
+  )
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -146,7 +146,18 @@ variable "budget_alert_emails" {
   default     = []
 }
 
-# --- Edge (Lightsail container service) ---------------------------------------
+# --- Edge (host-agnostic + per-host knobs) ------------------------------------
+
+variable "edge_host" {
+  type        = string
+  description = "Where the always-on edge runs: \"lightsail\" (container service) or \"fargate\" (ECS). Swappable at any time."
+  default     = "lightsail"
+
+  validation {
+    condition     = contains(["lightsail", "fargate"], var.edge_host)
+    error_message = "edge_host must be \"lightsail\" or \"fargate\"."
+  }
+}
 
 variable "discord_token_ssm_parameter" {
   type        = string
@@ -162,8 +173,20 @@ variable "edge_power" {
 
 variable "edge_scale" {
   type        = number
-  description = "Number of container nodes (replicas). 1 always-on holder."
+  description = "Number of Lightsail container nodes (replicas). 1 always-on holder."
   default     = 1
+}
+
+variable "edge_cpu" {
+  type        = number
+  description = "Fargate task CPU units (256 = 0.25 vCPU). Must pair with a valid edge_memory."
+  default     = 256
+}
+
+variable "edge_memory" {
+  type        = number
+  description = "Fargate task memory (MB). 512 is ample for the ~76MB edge; 256 CPU allows 512/1024/2048."
+  default     = 512
 }
 
 variable "edge_image_tag" {


### PR DESCRIPTION
Adds **Fargate** as a swappable edge host so we're not blocked by Lightsail's new-account 0-quota, and so the host can be changed any time (your call: "I can swap provider at any time anyway").

## The switch
`EDGE_HOST` Variable selects where the edge runs — **`lightsail`** (default) or **`fargate`**. The unused host's resources are simply `count = 0`. Both run the **same amd64 edge image from the same ECR repo**; flip the variable and re-run Deploy to swap.

## Fargate path (`edge_fargate.tf`)
- ECS Fargate service in the **default VPC** — egress-only SG, **public IP** for IPv4 egress to Discord, no inbound.
- **IAM task role** = `lambda:InvokeFunction` on the worker → the edge needs **no static key** here (cleaner than Lightsail).
- **Execution role** pulls the image + writes logs + reads the token; **ECS fetches `DISCORD_TOKEN` from SSM at launch** (never in TF state).
- CloudWatch log group `/ecs/petbot-edge`. amd64 task (matches `Dockerfile.edge`).
- ~$11/mo (compute + a public IPv4) vs Lightsail's ~$7.

## Other changes
- `edge.tf`: Lightsail resources (+ its scoped IAM user) gated on `edge_host == "lightsail"`; the edge ECR repo is shared.
- `variables.tf`: `edge_host` (validated) + `edge_cpu`/`edge_memory`.
- `outputs.tf`: `edge_host` + host-agnostic `edge_service_name`.
- **bootstrap deploy role**: adds `ecs:*`, scoped EC2 networking/SG, the two task roles + `PassRole` to `ecs-tasks`, and the `/ecs/petbot-edge` log group. ⚠️ **The deploy role must be re-applied (bootstrap) before deploying on Fargate**, or it'll `AccessDenied` again.
- `deploy.yml`: `TF_VAR_edge_host` from the `EDGE_HOST` Variable (unset ⇒ lightsail).

## Verification
- `terraform fmt -check` + `validate` (root + bootstrap) ✅. No app code touched.
- The live Fargate path (puller-free ECR pull by ECS, task role, SSM secret fetch) gets exercised on the first real deploy.

## Deploy sequence (with the new host)
1. Re-apply **bootstrap** (grants the role the ECS/EC2/IAM perms).
2. Set Variable `EDGE_HOST=fargate`.
3. Merge → Deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018AE3E1MRysoTBHxgQhH1rA)_