### PR TITLE
ci: skip Claude review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs: they're mechanical dependency bumps where AI review
+    # adds little, and Dependabot runs can't read Actions secrets anyway (they
+    # use a separate Dependabot secret store), so the review would fail at auth.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,13 +35,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Allow Dependabot-authored PRs to be reviewed. claude-code-action blocks
-          # bot actors by default; scope this to dependabot rather than '*' to avoid
-          # letting arbitrary bots trigger Claude. NOTE: Dependabot pull_request runs
-          # read secrets from the *Dependabot* secrets store, not Actions secrets, so
-          # CLAUDE_CODE_OAUTH_TOKEN must also be added under
-          # Settings -> Secrets and variables -> Dependabot.
-          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow Dependabot-authored PRs to be reviewed. claude-code-action blocks
+          # bot actors by default; scope this to dependabot rather than '*' to avoid
+          # letting arbitrary bots trigger Claude. NOTE: Dependabot pull_request runs
+          # read secrets from the *Dependabot* secrets store, not Actions secrets, so
+          # CLAUDE_CODE_OAUTH_TOKEN must also be added under
+          # Settings -> Secrets and variables -> Dependabot.
+          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## What

Dependabot PR #57 failed Claude review with:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
```

Rather than wire Claude up to run on Dependabot PRs (which would also require copying `CLAUDE_CODE_OAUTH_TOKEN` into the separate **Dependabot** secret store), this **skips** Claude review on Dependabot PRs with an `if:` guard on the `claude-review` job:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

## Why skip instead of enable

- Dependabot PRs are mechanical version bumps — AI review adds little value and burns Claude usage on every dependency PR.
- GitHub deliberately hides Actions secrets from Dependabot runs (security: an untrusted dependency update shouldn't reach secrets), so the review would fail at Anthropic auth anyway.
- Matches common community practice: exclude bots from AI review; gate Dependabot on real CI instead.

Normal/human PRs are unaffected — Claude review still runs on them.

## No manual step required

No Dependabot secret needed. This supersedes the earlier `allowed_bots` approach (reverted in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)