### PR TITLE
chore: rename default branch master → main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ name: Deploy
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
 
 # OIDC: request a short-lived token to assume the AWS deploy role.
 permissions:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,7 +1,7 @@
 name: Images
 
 # Build (do NOT push) both deploy images on every PR/branch that touches them, so
-# a broken Dockerfile or dependency surfaces at review time — not at a master
+# a broken Dockerfile or dependency surfaces at review time — not at a main
 # deploy. No AWS credentials or registry access needed. Each image builds on its
 # native runner arch (worker arm64, edge amd64) so there's no slow emulation.
 on:

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -101,14 +101,14 @@ endpoint**, so for Gemma 4 use `CHAT_LLM_KIND=openai_compatible` with the
 different base URL.
 
 That's the complete list — once these Variables and the SSM secrets above exist,
-a push to `master` runs a green deploy. (Merging the PR alone does **not** create
+a push to `main` runs a green deploy. (Merging the PR alone does **not** create
 them; this one-time setup is yours to do.)
 
 ## CI deploy (the steady-state path)
 
 `.github/workflows/deploy.yml` does the whole rollout via OIDC: build + push both
 images to ECR (arm64 worker, amd64 edge), then `terraform apply` (the Lightsail
-edge pulls its image from ECR). A push to `master` (or a manual *Actions → Deploy
+edge pulls its image from ECR). A push to `main` (or a manual *Actions → Deploy
 → Run workflow*) ships it. **No deploy is run from a developer machine.**
 
 ## Deploy (manual / break-glass)


### PR DESCRIPTION
## What

Retargets the in-repo references from `master` to `main` ahead of renaming the default branch on GitHub.

| File | Type | Change |
|------|------|--------|
| `.github/workflows/deploy.yml` | **functional** | push trigger `branches: [master]` → `[main]` |
| `.github/workflows/images.yml` | comment | "...not at a master" → "main" |
| `deploy/terraform/README.md` | prose (×2) | `master` → `main` |

`ci.yml`, `terraform.yml`, `images.yml` triggers are branch-agnostic (`["**"]`) — no change needed. `claude*.yml` only reference `main` in action-repo URLs.

## Rename sequence (do these around merging this PR)

1. **Rename on GitHub first** (Settings → Branches, or `gh api -X POST repos/auzbuzzard/petbot/branches/master/rename -f new_name=main`). This re-targets open PRs, migrates branch protection, and updates the default branch.
2. Merge this PR into `main`.
3. Local clones: `git branch -m master main && git fetch origin && git branch -u origin/main main && git remote set-head origin -a`.
4. Verify: default branch = `main`, branch protection moved, `production` environment gate intact (driven by `environment:`, not branch name).

⚠️ Until step 1 is done, `deploy.yml` won't fire on `main` pushes (and no longer fires on `master`). Sequence the rename close to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjGs25AcQvqC28tQYaiErc)_