### PR TITLE
feat(edge): slash commands over the gateway (/math, /derpi, /e621)

### DIFF
--- a/src/petbot/edge/bot.py
+++ b/src/petbot/edge/bot.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Awaitable
-from typing import assert_never
+from inspect import Parameter, Signature
+from typing import Any, assert_never
 
 import discord
 import httpx
@@ -28,7 +29,7 @@ from petbot.edge.render import respond, respond_interaction
 from petbot.edge.settings import EdgeSettings, HttpWorker, LambdaWorker
 from petbot.logging_setup import configure_logging
 from petbot.platform import HttpTransport, LambdaTransport, SkillsClient
-from petbot.types import BooruArgs, ChatArgs, MathArgs, Skills
+from petbot.types import COMMANDS, ChatArgs, CommandSpec, Skills
 
 logger = logging.getLogger(__name__)
 
@@ -78,28 +79,43 @@ class PetBot(commands.Bot):
         return self.skills
 
     def _register_slash_commands(self) -> None:
-        """One slash command per dispatched skill, defined from the typed ``*Args``
-        surface and the ``Skills`` client — so the edge still never imports a skill."""
+        """One slash command per manifest entry, its options generated from the
+        skill's ``args_model`` — so the edge hand-lists neither skills nor args."""
+        for spec in COMMANDS:
+            self.tree.add_command(self._build_command(spec))
 
-        @self.tree.command(name="math", description="Evaluate an arithmetic expression.")
-        @app_commands.describe(expression="e.g. 2 + 2 * 10")
-        async def math(interaction: discord.Interaction, expression: str) -> None:
+    def _build_command(self, spec: CommandSpec) -> app_commands.Command[Any, ..., None]:
+        """Turn a manifest entry into a slash command: one option per ``args_model``
+        field (its name, type, and required/optional read straight off the model),
+        dispatched through the Skills client by the shared :meth:`_run_slash`."""
+
+        async def callback(interaction: discord.Interaction, **values: Any) -> None:
+            args = spec.args_model(**values)
             ctx = build_interaction_context(interaction)
-            await self._run_slash(
-                interaction, self._client.math(MathArgs(expression=expression), ctx)
+            await self._run_slash(interaction, spec.invoke(self._client, args, ctx))
+
+        params = [
+            Parameter(
+                "interaction", Parameter.POSITIONAL_OR_KEYWORD, annotation=discord.Interaction
             )
-
-        @self.tree.command(name="derpi", description="Search Derpibooru for an image.")
-        @app_commands.describe(tags="Space-separated tags")
-        async def derpi(interaction: discord.Interaction, tags: str) -> None:
-            ctx = build_interaction_context(interaction)
-            await self._run_slash(interaction, self._client.derpi(BooruArgs(tags=tags), ctx))
-
-        @self.tree.command(name="e621", description="Search e621 (furry imageboard) for an image.")
-        @app_commands.describe(tags="Space-separated tags")
-        async def e621(interaction: discord.Interaction, tags: str) -> None:
-            ctx = build_interaction_context(interaction)
-            await self._run_slash(interaction, self._client.e621(BooruArgs(tags=tags), ctx))
+        ]
+        for name, field_info in spec.args_model.model_fields.items():
+            default = Parameter.empty if field_info.is_required() else field_info.default
+            params.append(
+                Parameter(
+                    name,
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=field_info.annotation,
+                    default=default,
+                )
+            )
+        # discord.py reads the callback's signature to build the options; the real
+        # callback takes **values, so attach the schema-bearing signature explicitly.
+        callback.__signature__ = Signature(params)  # type: ignore[attr-defined]
+        callback.__discord_app_commands_param_description__ = {  # type: ignore[attr-defined]
+            name: name.replace("_", " ") for name in spec.args_model.model_fields
+        }
+        return app_commands.Command(name=spec.name, description=spec.description, callback=callback)
 
     async def _sync_commands(self) -> None:
         """Register the app commands with Discord. ``dev_guild_id`` syncs to that

--- a/src/petbot/edge/bot.py
+++ b/src/petbot/edge/bot.py
@@ -1,30 +1,34 @@
-"""The Discord edge: hold the gateway, turn an @mention into a chat call, render.
+"""The Discord edge: hold the gateway, turn an @mention or slash command into a
+dispatched call, render the result.
 
-The thin, always-on process. It runs no skills: every mention is dispatched to a
-worker through the typed :class:`petbot.types.Skills` client (a
-:class:`~petbot.platform.SkillsClient` over an HTTP or Lambda transport), and the
-worker's neutral :class:`~petbot.domain.result.SkillResult` is rendered back to
-the channel. It owns a live connection, so it is smoke-tested manually against a
-dev guild rather than in CI.
+The thin, always-on process. It runs no skills: every @mention (chat) and every
+slash command is dispatched to a worker through the typed :class:`petbot.types.Skills`
+client (a :class:`~petbot.platform.SkillsClient` over an HTTP or Lambda transport),
+and the worker's neutral :class:`~petbot.domain.result.SkillResult` is rendered back.
+Slash commands are defined from the typed ``*Args`` surface, so the edge still never
+imports a skill. It owns a live connection, so the gateway wiring is smoke-tested
+manually against a dev guild; the dispatch/render helpers are unit-tested with fakes.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Awaitable
 from typing import assert_never
 
 import discord
 import httpx
+from discord import app_commands
 from discord.ext import commands
 
 from petbot.domain import SkillResult
-from petbot.edge.context import build_context
-from petbot.edge.render import respond
+from petbot.edge.context import build_context, build_interaction_context
+from petbot.edge.render import respond, respond_interaction
 from petbot.edge.settings import EdgeSettings, HttpWorker, LambdaWorker
 from petbot.logging_setup import configure_logging
 from petbot.platform import HttpTransport, LambdaTransport, SkillsClient
-from petbot.types import ChatArgs, Skills
+from petbot.types import BooruArgs, ChatArgs, MathArgs, Skills
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +69,64 @@ class PetBot(commands.Bot):
                 self.skills = SkillsClient(HttpTransport(url, self._http))
             case _:
                 assert_never(worker)
+        self._register_slash_commands()
+        await self._sync_commands()
+
+    @property
+    def _client(self) -> Skills:
+        assert self.skills is not None  # set above in setup_hook, before any interaction
+        return self.skills
+
+    def _register_slash_commands(self) -> None:
+        """One slash command per dispatched skill, defined from the typed ``*Args``
+        surface and the ``Skills`` client — so the edge still never imports a skill."""
+
+        @self.tree.command(name="math", description="Evaluate an arithmetic expression.")
+        @app_commands.describe(expression="e.g. 2 + 2 * 10")
+        async def math(interaction: discord.Interaction, expression: str) -> None:
+            ctx = build_interaction_context(interaction)
+            await self._run_slash(
+                interaction, self._client.math(MathArgs(expression=expression), ctx)
+            )
+
+        @self.tree.command(name="derpi", description="Search Derpibooru for an image.")
+        @app_commands.describe(tags="Space-separated tags")
+        async def derpi(interaction: discord.Interaction, tags: str) -> None:
+            ctx = build_interaction_context(interaction)
+            await self._run_slash(interaction, self._client.derpi(BooruArgs(tags=tags), ctx))
+
+        @self.tree.command(name="e621", description="Search e621 (furry imageboard) for an image.")
+        @app_commands.describe(tags="Space-separated tags")
+        async def e621(interaction: discord.Interaction, tags: str) -> None:
+            ctx = build_interaction_context(interaction)
+            await self._run_slash(interaction, self._client.e621(BooruArgs(tags=tags), ctx))
+
+    async def _sync_commands(self) -> None:
+        """Register the app commands with Discord. ``dev_guild_id`` syncs to that
+        guild (instant, for iteration); otherwise a global sync (which Discord can
+        take up to an hour to propagate the first time)."""
+        if self.settings.dev_guild_id is not None:
+            guild = discord.Object(id=self.settings.dev_guild_id)
+            self.tree.copy_global_to(guild=guild)
+            await self.tree.sync(guild=guild)
+        else:
+            await self.tree.sync()
+
+    async def _run_slash(
+        self, interaction: discord.Interaction, call: Awaitable[SkillResult]
+    ) -> None:
+        """Defer, run the dispatched ``call``, send the result as a followup.
+
+        Defer first: a dispatch can exceed Discord's 3s interaction window on a
+        Lambda cold start. A transport failure maps to a friendly result, not a crash.
+        """
+        await interaction.response.defer()
+        try:
+            result = await call
+        except Exception:
+            logger.exception("slash dispatch failed")
+            result = SkillResult.failure(_WORKER_UNREACHABLE)
+        await respond_interaction(interaction, result)
 
     async def on_ready(self) -> None:
         if self.user is not None:

--- a/src/petbot/edge/context.py
+++ b/src/petbot/edge/context.py
@@ -12,9 +12,12 @@ import discord
 from petbot.domain import Platform, SkillContext, User
 
 
-def _channel_is_nsfw(channel: object) -> bool:
-    """True if ``channel`` is an age-gated Discord channel. Typed ``object`` so it
-    serves both a message channel and an interaction channel (DMs lack the flag)."""
+def _channel_is_nsfw(
+    channel: discord.abc.MessageableChannel | discord.abc.GuildChannel | None,
+) -> bool:
+    """True if ``channel`` is an age-gated Discord channel. The union covers a
+    message's channel and a slash interaction's channel alike; ``is_nsfw`` is read
+    defensively because some channel kinds (a DM) don't carry the flag."""
     is_nsfw = getattr(channel, "is_nsfw", None)
     return bool(is_nsfw()) if callable(is_nsfw) else False
 

--- a/src/petbot/edge/context.py
+++ b/src/petbot/edge/context.py
@@ -1,7 +1,8 @@
-"""Build a neutral :class:`SkillContext` from a Discord message.
+"""Build a neutral :class:`SkillContext` from a Discord message or slash interaction.
 
 The one place Discord nouns (channels, members, NSFW flags) map onto the neutral
-context — the only direction the dependency rule allows.
+context — the only direction the dependency rule allows. An @mention and a slash
+command map through the twin functions here, so a skill sees them identically.
 """
 
 from __future__ import annotations
@@ -11,7 +12,9 @@ import discord
 from petbot.domain import Platform, SkillContext, User
 
 
-def _channel_is_nsfw(channel: discord.abc.MessageableChannel) -> bool:
+def _channel_is_nsfw(channel: object) -> bool:
+    """True if ``channel`` is an age-gated Discord channel. Typed ``object`` so it
+    serves both a message channel and an interaction channel (DMs lack the flag)."""
     is_nsfw = getattr(channel, "is_nsfw", None)
     return bool(is_nsfw()) if callable(is_nsfw) else False
 
@@ -33,4 +36,24 @@ def build_context(message: discord.Message) -> SkillContext:
         user=user,
         conversation_id=f"discord:{message.channel.id}",
         allows_explicit=_channel_is_nsfw(message.channel),
+    )
+
+
+def build_interaction_context(interaction: discord.Interaction) -> SkillContext:
+    """Map a slash-command ``interaction`` onto a :class:`SkillContext`.
+
+    The interaction twin of :func:`build_context`: same neutral mapping (NSFW flag,
+    channel as the conversation id) so a slash command reaches a skill on the exact
+    path an @mention does.
+    """
+    user = User(
+        platform=Platform.DISCORD,
+        id=str(interaction.user.id),
+        display_name=interaction.user.display_name,
+    )
+    return SkillContext(
+        platform=Platform.DISCORD,
+        user=user,
+        conversation_id=f"discord:{interaction.channel_id}",
+        allows_explicit=_channel_is_nsfw(interaction.channel),
     )

--- a/src/petbot/edge/render.py
+++ b/src/petbot/edge/render.py
@@ -1,10 +1,14 @@
 """Render neutral :class:`SkillResult` values into Discord messages.
 
 The *only* place neutral results become Discord types. :func:`to_embed` is a pure
-mapping (unit-tested without a gateway); :func:`respond` wires it to a channel.
+mapping (unit-tested without a gateway); :func:`respond` wires it to a channel (the
+@mention path) and :func:`respond_interaction` to a slash-command followup. Both
+shape the result identically via :func:`_plan`.
 """
 
 from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
 
 import discord
 
@@ -31,29 +35,49 @@ def to_embed(spec: EmbedSpec) -> discord.Embed:
     return embed
 
 
+def _plan(result: SkillResult) -> list[tuple[str | None, discord.Embed | None]]:
+    """The ordered messages a result becomes: an error is one plain message;
+    otherwise the text is chunked and the embed rides only the first chunk."""
+    if result.is_error:
+        return [(result.error, None)]
+    embed = to_embed(result.embed) if result.embed is not None else None
+    chunks = chunk_text(result.text or "", limit=DISCORD_MAX_TEXT)
+    if not chunks:
+        # No text: the embed alone, or nothing if the result is truly empty.
+        return [(None, embed)] if embed is not None else []
+    return [(chunk, embed if index == 0 else None) for index, chunk in enumerate(chunks)]
+
+
+async def _send(
+    sender: Callable[..., Awaitable[object]],
+    content: str | None,
+    embed: discord.Embed | None,
+) -> None:
+    # Pass `embed` only when present so the call matches discord.py's non-optional
+    # `embed` overload (a None embed must never reach the gateway).
+    if embed is None:
+        await sender(content=content)
+    elif content is None:
+        await sender(embed=embed)
+    else:
+        await sender(content=content, embed=embed)
+
+
 async def respond(channel: discord.abc.Messageable, result: SkillResult) -> None:
-    """Send ``result`` to ``channel``.
+    """Send ``result`` to ``channel`` (the @mention path).
 
     Expected failures render as a plain message; successes send the text (chunked)
     and, on the first message, the embed.
     """
-    if result.is_error:
-        await channel.send(content=result.error)
-        return
+    for content, embed in _plan(result):
+        await _send(channel.send, content, embed)
 
-    embed = to_embed(result.embed) if result.embed is not None else None
-    chunks = chunk_text(result.text or "", limit=DISCORD_MAX_TEXT)
 
-    if not chunks:
-        # No text: send the embed alone, or nothing if the result is truly empty.
-        if embed is not None:
-            await channel.send(embed=embed)
-        return
+async def respond_interaction(interaction: discord.Interaction, result: SkillResult) -> None:
+    """Send ``result`` as the followup to an already-deferred slash ``interaction``.
 
-    for index, chunk in enumerate(chunks):
-        # The embed rides only the first message; pass it only when present so the
-        # call matches discord.py's non-optional `embed` overload.
-        if embed is not None and index == 0:
-            await channel.send(content=chunk, embed=embed)
-        else:
-            await channel.send(content=chunk)
+    The interaction twin of :func:`respond`: identical shaping, but each message is
+    a ``followup.send`` (the caller has already deferred the interaction response).
+    """
+    for content, embed in _plan(result):
+        await _send(interaction.followup.send, content, embed)

--- a/src/petbot/skills/chat/agent.py
+++ b/src/petbot/skills/chat/agent.py
@@ -1,22 +1,23 @@
-"""The pydantic-ai agent: persona, dependency wiring, and sibling-skill tools.
+"""The pydantic-ai agent: persona, dependency wiring, and manifest-driven tools.
 
-Each sibling skill is exposed to the LLM as a typed tool whose argument is the
-very same ``petbot.types`` ``*Args`` model the skill validates — so the tool
-schema, the typed client call, and the worker's validation all share one source
-of truth. Tool bodies dispatch through a :class:`petbot.types.Skills` client (a
-``SkillsClient`` over a local transport in the core worker — an in-process hop,
-no wire round trip). A tool that yields a rich card (a booru image) records it on
-the deps so the chat skill can surface it alongside the model's prose.
+Each entry in :data:`petbot.types.COMMANDS` becomes one LLM tool: its schema is the
+skill's own ``args_model`` and its body dispatches through a
+:class:`petbot.types.Skills` client (a ``SkillsClient`` over a local transport in the
+core worker — an in-process hop, no wire round trip). So the tool schema, the typed
+client call, the worker's validation, and the edge's slash command all share one
+declaration; the agent hand-lists no skill. A tool that yields a rich card (a booru
+image) records it on the deps so the chat skill can surface it with the model's prose.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, RunContext, Tool
 
 from petbot.domain import SkillContext, SkillResult
-from petbot.types import BooruArgs, MathArgs, Skills
+from petbot.types import COMMANDS, CommandSpec, Skills
 
 
 @dataclass
@@ -44,34 +45,34 @@ def _summarise(deps: ChatDeps, result: SkillResult) -> str:
     return "\n".join(parts) or "Done."
 
 
-def build_agent(system_prompt: str) -> Agent[ChatDeps, str]:
-    """Build the chat agent with the sibling-skill tools registered.
+def _tool_for(spec: CommandSpec) -> Tool[ChatDeps]:
+    """Build one LLM tool from a manifest entry: schema from ``args_model``, body
+    dispatches through the Skills client and summarises the result for the model."""
 
-    The model is bound per run (``agent.run(..., model=...)``) so the same agent
-    object serves both the configured provider and ``TestModel`` in tests.
-    """
-    agent: Agent[ChatDeps, str] = Agent(
-        deps_type=ChatDeps,
-        output_type=str,
-        # pydantic-ai 'instructions' (not 'system_prompt'): for a single agent it is
-        # excluded from message history, and static instructions sort first so a
-        # caching provider (Bedrock) can cache the stable prefix.
-        instructions=system_prompt,
+    async def run(ctx: RunContext[ChatDeps], **values: Any) -> str:
+        args = spec.args_model(**values)
+        result = await spec.invoke(ctx.deps.skills, args, ctx.deps.ctx)
+        return _summarise(ctx.deps, result)
+
+    return Tool.from_schema(
+        run,
+        name=spec.name,
+        description=spec.description,
+        json_schema=spec.args_model.model_json_schema(),
+        takes_ctx=True,
     )
 
-    @agent.tool
-    async def math(ctx: RunContext[ChatDeps], args: MathArgs) -> str:
-        """Evaluate an arithmetic expression."""
-        return _summarise(ctx.deps, await ctx.deps.skills.math(args, ctx.deps.ctx))
 
-    @agent.tool
-    async def derpi(ctx: RunContext[ChatDeps], args: BooruArgs) -> str:
-        """Search Derpibooru (My Little Pony imageboard) for an image."""
-        return _summarise(ctx.deps, await ctx.deps.skills.derpi(args, ctx.deps.ctx))
+def build_agent(system_prompt: str) -> Agent[ChatDeps, str]:
+    """Build the chat agent with one tool per :data:`~petbot.types.COMMANDS` entry.
 
-    @agent.tool
-    async def e621(ctx: RunContext[ChatDeps], args: BooruArgs) -> str:
-        """Search e621 (furry imageboard) for an image."""
-        return _summarise(ctx.deps, await ctx.deps.skills.e621(args, ctx.deps.ctx))
-
-    return agent
+    Adding a skill to the manifest adds its tool here for free — no per-skill code.
+    The model is bound per run (``agent.run(..., model=...)``) so the same agent
+    serves both the configured provider and ``TestModel`` in tests.
+    """
+    return Agent(
+        deps_type=ChatDeps,
+        output_type=str,
+        instructions=system_prompt,
+        tools=[_tool_for(spec) for spec in COMMANDS],
+    )

--- a/src/petbot/types/__init__.py
+++ b/src/petbot/types/__init__.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 from petbot.types.args import BooruArgs, ChatArgs, MathArgs, MusicAction, MusicArgs
 from petbot.types.client import Skills
+from petbot.types.manifest import COMMANDS, CommandSpec
 
 __all__ = [
+    "COMMANDS",
     "BooruArgs",
     "ChatArgs",
+    "CommandSpec",
     "MathArgs",
     "MusicAction",
     "MusicArgs",

--- a/src/petbot/types/manifest.py
+++ b/src/petbot/types/manifest.py
@@ -1,0 +1,65 @@
+"""The command manifest — every dispatched skill as data, in one place.
+
+This is the single source the *frontends* derive their command surface from: the
+chat agent registers one LLM tool per entry, and the Discord edge one slash command
+per entry — both by looping :data:`COMMANDS`, neither hand-listing skills. A command
+is ``(name, description, args_model, invoke)``:
+
+* ``name`` / ``description`` — the user- and LLM-facing copy (slash name + help,
+  tool name + description);
+* ``args_model`` — the parameter schema. The slash options and the LLM tool schema
+  are both *generated* from it, so the model stays the one source for arguments;
+* ``invoke`` — dispatch the validated args through the typed
+  :class:`~petbot.types.client.Skills` client.
+
+It lives in the typed surface (not beside the skills) so the edge consumes it without
+importing a skill — the dependency rule the architecture turns on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from petbot.domain import SkillContext, SkillResult
+from petbot.types.args import BooruArgs, MathArgs
+from petbot.types.client import Skills
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """One dispatched skill, as data — the source both frontends derive from."""
+
+    name: str
+    description: str
+    args_model: type[BaseModel]
+    #: Dispatch the (already-validated) args through a Skills client.
+    invoke: Callable[[Skills, Any, SkillContext], Awaitable[SkillResult]]
+
+
+#: Every skill the edge exposes as a slash command and the chat agent offers as a
+#: tool. Adding a skill here is the only edit either frontend needs. (Music is absent
+#: by design — it lives on a separate worker, not the core the edge dispatches to.)
+COMMANDS: tuple[CommandSpec, ...] = (
+    CommandSpec(
+        name="math",
+        description="Evaluate an arithmetic expression.",
+        args_model=MathArgs,
+        invoke=lambda skills, args, ctx: skills.math(args, ctx),
+    ),
+    CommandSpec(
+        name="derpi",
+        description="Search Derpibooru (My Little Pony imageboard) for an image.",
+        args_model=BooruArgs,
+        invoke=lambda skills, args, ctx: skills.derpi(args, ctx),
+    ),
+    CommandSpec(
+        name="e621",
+        description="Search e621 (furry imageboard) for an image.",
+        args_model=BooruArgs,
+        invoke=lambda skills, args, ctx: skills.e621(args, ctx),
+    ),
+)

--- a/tests/edge/test_render.py
+++ b/tests/edge/test_render.py
@@ -9,8 +9,8 @@ import discord
 
 from petbot.domain import EmbedSpec, Platform, SkillResult
 from petbot.edge.bot import PetBot, _without_mention
-from petbot.edge.context import build_context
-from petbot.edge.render import respond, to_embed
+from petbot.edge.context import build_context, build_interaction_context
+from petbot.edge.render import respond, respond_interaction, to_embed
 from petbot.edge.settings import EdgeSettings, HttpWorker
 from petbot.edge.text import chunk_text
 
@@ -108,3 +108,76 @@ async def test_chat_maps_transport_error_to_friendly_failure() -> None:
     bot.skills = _RaisingSkills()
     result = await bot._chat("hello", FakeMessage(FakeChannel()))  # type: ignore[arg-type]
     assert result.is_error  # the transport failure became a friendly result, not a crash
+
+
+# --- slash commands ----------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self) -> None:
+        self.deferred = False
+
+    async def defer(self) -> None:
+        self.deferred = True
+
+
+class FakeFollowup:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+
+    async def send(self, content: str | None = None, embed: discord.Embed | None = None) -> None:
+        self.sent.append({"content": content, "embed": embed})
+
+
+class FakeInteraction:
+    """Captures defer + followups for a slash command, without a gateway."""
+
+    def __init__(self, *, nsfw: bool = False, channel_id: int = 99) -> None:
+        self.user = FakeAuthor()
+        self.channel = FakeChannel(nsfw=nsfw, channel_id=channel_id)
+        self.channel_id = channel_id
+        self.response = FakeResponse()
+        self.followup = FakeFollowup()
+
+
+def test_build_interaction_context_reads_nsfw_and_ids() -> None:
+    ctx = build_interaction_context(FakeInteraction(nsfw=True, channel_id=8))  # type: ignore[arg-type]
+    assert ctx.platform is Platform.DISCORD
+    assert ctx.allows_explicit is True
+    assert ctx.conversation_id == "discord:8"
+    assert ctx.user.display_name == "Rex"
+    sfw = build_interaction_context(FakeInteraction(nsfw=False))  # type: ignore[arg-type]
+    assert sfw.allows_explicit is False
+
+
+async def test_respond_interaction_sends_card_as_followup() -> None:
+    interaction = FakeInteraction()
+    result = SkillResult.message("here", embed=EmbedSpec(title="c", image_url="http://i/x"))
+    await respond_interaction(interaction, result)  # type: ignore[arg-type]
+    assert interaction.followup.sent[0]["content"] == "here"
+    assert interaction.followup.sent[0]["embed"] is not None
+
+
+async def test_run_slash_defers_then_followups_the_result() -> None:
+    bot = PetBot(EdgeSettings(discord_token="x", worker=HttpWorker(url="http://worker/dispatch")))
+    interaction = FakeInteraction()
+
+    async def ok() -> SkillResult:
+        return SkillResult.message("done")
+
+    await bot._run_slash(interaction, ok())  # type: ignore[arg-type]
+    assert interaction.response.deferred is True
+    assert interaction.followup.sent[0]["content"] == "done"
+
+
+async def test_run_slash_maps_transport_error_to_friendly_followup() -> None:
+    bot = PetBot(EdgeSettings(discord_token="x", worker=HttpWorker(url="http://worker/dispatch")))
+    interaction = FakeInteraction()
+
+    async def boom() -> SkillResult:
+        raise RuntimeError("worker unreachable")
+
+    await bot._run_slash(interaction, boom())  # type: ignore[arg-type]
+    assert interaction.response.deferred is True
+    # the failure became a friendly followup, not a crash
+    assert interaction.followup.sent[0]["content"]

--- a/tests/edge/test_render.py
+++ b/tests/edge/test_render.py
@@ -13,6 +13,7 @@ from petbot.edge.context import build_context, build_interaction_context
 from petbot.edge.render import respond, respond_interaction, to_embed
 from petbot.edge.settings import EdgeSettings, HttpWorker
 from petbot.edge.text import chunk_text
+from petbot.types import COMMANDS
 
 
 class FakeChannel:
@@ -181,3 +182,16 @@ async def test_run_slash_maps_transport_error_to_friendly_followup() -> None:
     assert interaction.response.deferred is True
     # the failure became a friendly followup, not a crash
     assert interaction.followup.sent[0]["content"]
+
+
+def test_slash_command_options_are_generated_from_args_model() -> None:
+    # The edge hand-lists no options: each command's parameters are read straight
+    # off the skill's args_model, required/optional preserved.
+    bot = PetBot(EdgeSettings(discord_token="x", worker=HttpWorker(url="http://worker/dispatch")))
+    spec = next(s for s in COMMANDS if s.name == "e621")
+    command = bot._build_command(spec)
+    assert command.name == "e621"
+    params = command._params
+    assert set(params) == set(spec.args_model.model_fields)
+    assert params["tags"].required is True  # BooruArgs.tags is required
+    assert params["sort"].required is False  # BooruArgs.sort is optional

--- a/tests/skills/chat/test_chat.py
+++ b/tests/skills/chat/test_chat.py
@@ -11,7 +11,7 @@ from petbot.domain import EmbedSpec, Platform, SkillContext, SkillResult, User
 from petbot.skills.chat import ChatSkill
 from petbot.skills.chat.model import build_model
 from petbot.skills.chat.settings import ChatSettings, OpenAICompatibleModel, OpenRouterModel
-from petbot.types import BooruArgs, ChatArgs, MathArgs, MusicArgs
+from petbot.types import COMMANDS, BooruArgs, ChatArgs, MathArgs, MusicArgs
 
 
 def test_llm_config_is_required(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,3 +136,12 @@ async def test_skill_error_does_not_crash_the_agent() -> None:
     result = await skill.run(ChatArgs(message="find a fox"), _ctx())
     assert "e621" in fake.called
     assert not result.is_error  # the failure is reported to the model, not raised
+
+
+async def test_manifest_invoke_dispatches_to_its_skill() -> None:
+    # Each manifest entry dispatches through the Skills client to its named skill —
+    # the one wiring the agent's tools and the edge's slash commands both ride on.
+    fake = FakeSkills({"e621": SkillResult.message("ok")})
+    spec = next(s for s in COMMANDS if s.name == "e621")
+    await spec.invoke(fake, BooruArgs(tags="fox"), _ctx())
+    assert fake.called == ["e621"]


### PR DESCRIPTION
**Stacked on #61** (base = `claude/zen-hawking-f9db6d`; it reuses that PR's `_WORKER_UNREACHABLE`). Merge #61 first, or I can retarget to `master` after.

## Why
Slash commands don't work. RCA from the live edge logs: the Discord app still has an **Interactions Endpoint URL** set, so Discord routes interactions over HTTP (off the gateway) — discord.py warns this on every edge boot. And the code side ADR 0006 specced was never built: the edge only handled `@mention`, with no app-command handler. This PR is the code half.

## What
- **`bot.py`** — register `/math`, `/derpi`, `/e621` on the command tree, defined from the typed `*Args` surface + `Skills` client (edge still imports no skill). Sync in `setup_hook`: to `dev_guild_id` if set (instant), else global.
- **`_run_slash`** — `defer()` first (Lambda cold start can exceed Discord's 3s window), dispatch, `followup`; transport failure → friendly result.
- **`context.build_interaction_context`** — interaction twin of `build_context` (NSFW + channel id); `_channel_is_nsfw` widened to either channel type. A slash command reaches a skill identically to an `@mention`.
- **`render`** — `_plan`/`_send` factor the shaping; `respond_interaction` sends a deferred-interaction followup.

## ⚠️ Ops step required (not code, can't be done in the repo)
Clear the **Interactions Endpoint URL** in the Discord Developer Portal → General Information → Save. Until then, interactions never reach the gateway regardless of this code.

## Tests / gates
`build_interaction_context` mapping; `respond_interaction` followup; `_run_slash` defer + success + friendly-failure. ruff + format · mypy · lint-imports 4/4 · **pytest 68**.

`/music` is intentionally excluded — it lives on the separate music worker (ADR 0006 §2), not the edge.