### PR TITLE
Conversational memory: reply-to-continue + reactive context handling (ADR 0010)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ SERVICE__URL=http://127.0.0.1:8000/dispatch
 # SERVICE__KIND=lambda
 # SERVICE__FUNCTION_NAME=petbot-core
 
+# How many reply-chain ancestors to fetch when reconstructing conversation history
+# (a Discord-API cost bound, not a model-context bound). Default 25.
+# HISTORY_MAX_TURNS=25
+
 # ===================== Core compute service (math + booru + chat) ============
 # Run: python -m petbot.services.core  (or the `petbot-core` script)
 # --- Chat LLM (provider-agnostic; no vendor lock-in) — a tagged union ---
@@ -50,6 +54,10 @@ CHAT_LLM__API_KEY=op://Private/PetBot/openrouter_api_key
 # result in PetBot's voice. Unset ⇒ reuse CHAT_LLM__*. Tiering is config, not code.
 # CHAT_STYLIZER__KIND=bedrock
 # CHAT_STYLIZER__MODEL=amazon.nova-micro-v1:0
+# --- Context compaction (optional) — how an over-long conversation is shrunk *when the
+# model rejects it for length* (reactive; no token budget to set). Default: sliding
+# window (drop the oldest half, zero cost). `summarize` uses the stylizer-tier model.
+# CHAT_CONTEXT__KIND=summarize
 # Override the persona prompts (optional; sensible defaults ship as package data).
 # CHAT_SYSTEM_PROMPT=You are PetBot, a friendly companion. Keep replies short.
 # CHAT_STYLIZER_PROMPT=Rewrite the message below as one short line in PetBot's voice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ Organised by **concept** (`src/`), deployed by **service** (`deploy/` + `petbot.
 
 | Module | Role |
 |---|---|
-| `petbot.domain` | Kernel: frozen models (`SkillResult`, `SkillContext`, `EmbedSpec`, the `Input` sum type `TextInput \| CommandInput`), the `Process` verb + the `Skill[ArgsT]` tool ABC, ports (`VoicePort`, `StylePort`, `Notifier`), and `SkillError`. Imports nothing else first-party. |
-| `petbot.process` | **The core.** The `Process` impls: `ChatProcess` (the LLM brain), `CommandProcess`, the `RouterProcess` (the one exhaustive `match` on input type), and the persona voice (`Stylist` / `PassthroughStyle`, a `StylePort`). |
+| `petbot.domain` | Kernel: frozen models (`SkillResult`, `SkillContext`, `EmbedSpec`, the `Input` sum type `TextInput \| CommandInput` — `TextInput` carries reply-chain `history: tuple[Turn, …]`), the `Process` verb + the `Skill[ArgsT]` tool ABC, ports (`VoicePort`, `StylePort`, `Notifier`), and `SkillError`. Imports nothing else first-party. |
+| `petbot.process` | **The core.** The `Process` impls: `ChatProcess` (the LLM brain — maps `history` to `message_history` and **reactively compacts** it on a provider length-rejection, via a DI-selected `SlidingWindow`/`Summarizer`), `CommandProcess`, the `RouterProcess` (the one exhaustive `match` on input type), and the persona voice (`Stylist` / `PassthroughStyle`, a `StylePort`). |
 | `petbot.skills.{math,booru,music}` | One **tool** each (a `Skill[ArgsT]`); the process calls them through the `ToolRegistry`. Tools *raise* `SkillError` for expected failures. |
 | `petbot.types` | The typed surface a frontend imports without a skill: per-skill `*Args` models + the `Command` / `CATALOG`. |
 | `petbot.platform` | Plumbing: `ToolRegistry`, `serve`, `ProcessClient`, the `Dispatch` envelope + transports (`HttpTransport`, `LambdaTransport`). |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ branch) is preserved at the git tag **`v0.1-legacy-2018`**.
 
 ## What it does
 
-@mention PetBot and chat. The agent (pydantic-ai) decides when to call a tool:
+@mention PetBot to start a conversation, then **reply to its messages to keep it
+going** — no re-@mention needed; PetBot reconstructs the thread from the Discord reply
+chain. The agent (pydantic-ai) decides when to call a tool:
 
 | Tool | What it does |
 | --- | --- |

--- a/docs/adr/0010-conversational-memory-reply-to-continue.md
+++ b/docs/adr/0010-conversational-memory-reply-to-continue.md
@@ -1,0 +1,83 @@
+# ADR 0010: Conversational memory — reply-to-continue, reactive context handling
+
+- Status: Accepted
+- Date: 2026-06-22
+- Builds on the process pipeline ([ADR 0009](0009-process-pipeline.md)) and the chat
+  agent ([ADR 0007](0007-llm-agent-pydantic-ai.md)).
+
+## Context
+
+Chat was stateless single-shot: an `@mention` built `TextInput(text=…)` and the agent
+ran with **no `message_history`**, so replying to PetBot did nothing — the compute
+service only ever saw the latest message. Users expect to reply to PetBot and have it
+continue the conversation.
+
+Two facts shaped the design:
+
+1. The compute service is a **stateless Lambda** (ADR 0006/0009) — it can't hold
+   conversation state between requests.
+2. The frontend holds the gateway, so it is the **only** component that can read a
+   message's reply chain (`message.reference`).
+
+## Decision
+
+### Memory — reply-to-continue, reconstructed frontend-side (Route A)
+
+- A reply to one of PetBot's own messages continues the conversation, with **no
+  re-@mention** needed. `frontends/discord/history.py` walks `message.reference`
+  ancestors (bounded by `HISTORY_MAX_TURNS`, default 25 — a Discord-API cost bound, not
+  a model-context bound) and maps them to neutral `Turn` values.
+- History rides on **`TextInput.history`** — the conversational variant of the `Input`
+  sum type, so a `CommandInput` can't carry it. *Not* on the shared `SkillContext` (that
+  would reintroduce the cross-path baggage ADR 0009 removed) and *not* a compute-side
+  store (which can't see Discord's reply chain). The core stays a pure function of
+  `(Input, SkillContext)`.
+- `Role` is neutral `USER`/`ASSISTANT`; the speaker's name (including "PetBot") lives on
+  `Turn.author`, taken live from the Discord `display_name`. A user turn inlines its
+  author for multi-user attribution; an image-only bot card is **flattened to a faithful
+  text description** (its real title + image URL), since an assistant turn can only be
+  text in the model's history.
+- PetBot answers as a Discord reply (`mention_author=False`) so each answer is an anchor
+  to continue from.
+
+### Context window — reactive, no magic number
+
+- pydantic-ai does **not** expose a model's context-window *size*
+  ([#4538](https://redirect.github.com/pydantic/pydantic-ai/issues/4538)) and has no
+  turnkey compaction
+  ([#4137](https://redirect.github.com/pydantic/pydantic-ai/issues/4137)). A configured
+  token budget would be a magic number that is wrong the moment the model is swapped
+  (the provider config is built to be swapped).
+- So compaction is **reactive**: the chat process attempts the run, and only if the
+  provider rejects it for length (`is_context_overflow` — a best-effort `ModelHTTPError`
+  match) does it compact the message history and retry, bounded by
+  `MAX_COMPACTION_RETRIES`. The model's *real* window is the trigger; no budget is
+  invented.
+- The strategy is **DI-selectable** via `CHAT_CONTEXT__KIND` (a config `match`, like
+  `build_model_from_config`): a zero-cost **sliding window** (drop the oldest half) or an
+  **LLM summarizer** (a small stylizer-tier model summarises the oldest half).
+  `to_model_messages` stays a pure neutral→model mapper; the window strategy is separate.
+
+When the window size is exposed upstream, proactive precise budgeting can drop in behind
+the same seam.
+
+## Consequences
+
+- **Zero new infrastructure**; the Lambda stays a pure function, and no conversation
+  content lives at rest beyond Discord.
+- Memory is **Discord-shaped** — a second frontend would reconstruct its own way (or
+  motivate a compute-side store, deferred).
+- The compaction trigger depends on recognising a provider's length rejection, which is
+  provider-specific and best-effort: a false negative just skips the retry; a false
+  positive costs one needless compaction.
+
+## References
+
+- Builds on ADR 0009 (process pipeline), ADR 0007 (the chat agent), ADR 0006
+  (frontend/compute split).
+- Upstream gaps, linked without cross-referencing (the `redirect.github.com` host form,
+  as dependabot/Renovate use): pydantic-ai
+  [#4538](https://redirect.github.com/pydantic/pydantic-ai/issues/4538) (expose the
+  context-window size) and
+  [#4137](https://redirect.github.com/pydantic/pydantic-ai/issues/4137) (first-class
+  context compaction).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,9 @@ For the module map, the calling pattern, and the invariants, see
 - [ADR 0009](adr/0009-process-pipeline.md) — the process pipeline: the `Input` sum
   type, the `Process` verb (chat / command), the `ToolRegistry`, errors-as-exceptions,
   and the concept/service organisation. **The current end state.**
+- [ADR 0010](adr/0010-conversational-memory-reply-to-continue.md) — reply-to-continue
+  conversational memory (`TextInput.history`, reconstructed from the Discord reply
+  chain) and reactive context-window compaction.
 - [ADR 0006](adr/0006-gateway-edge-microservice-skills.md) — the original frontend +
   compute split and why music is its own service (vocabulary reshaped by 0009).
 - [ADR 0007](adr/0007-llm-agent-pydantic-ai.md) — the chat agent (pydantic-ai),
@@ -30,18 +33,21 @@ Discord ⇄ [ frontend ]  --Input(JSON)-->  [ core service ]  chat(LLM) · math 
                                                         petbot.services.music
 ```
 
-1. The frontend maps an `@mention` to a `TextInput` (and a slash command to a
-   `CommandInput`) plus a neutral `SkillContext`, and calls
-   `await process.respond(inp, ctx)` on its `ProcessClient` (a `Process` over a
-   transport).
+1. The frontend maps an `@mention` — or a **reply to PetBot** — to a `TextInput` (and a
+   slash command to a `CommandInput`) plus a neutral `SkillContext`. For a conversation,
+   it reconstructs the prior turns from the Discord reply chain into `TextInput.history`,
+   then calls `await process.respond(inp, ctx)` on its `ProcessClient` (a `Process` over
+   a transport).
 2. A `Dispatch` envelope carries the typed input. A remote transport
    (`HttpTransport`, `LambdaTransport`) serialises it at the boundary; `serve` decodes
    it on the compute side.
 3. A `RouterProcess` picks — by the input *type*, the one place anything branches —
-   the **chat process** (the pydantic-ai brain, which voices itself) or the **command
-   process** (which runs the resolved tool and applies the persona `StylePort`). Tools
-   are called in-process through the `ToolRegistry`; the agent's tools and the slash
-   surface both derive from one `CATALOG`.
+   the **chat process** (the pydantic-ai brain, which voices itself; it feeds
+   `TextInput.history` to the agent as message history and reactively compacts it — a
+   DI-selected sliding window or summarizer — only if the model rejects the conversation
+   for length) or the **command process** (which runs the resolved tool and applies the
+   persona `StylePort`). Tools are called in-process through the `ToolRegistry`; the
+   agent's tools and the slash surface both derive from one `CATALOG`.
 4. The service returns a neutral `SkillResult`; the frontend renders it (the one place
    neutral results become `discord.Embed`/messages). An expected failure is **raised**
    as a `SkillError` and voiced once at the process output boundary — there is no error

--- a/src/petbot/domain/__init__.py
+++ b/src/petbot/domain/__init__.py
@@ -17,7 +17,7 @@ from petbot.domain.errors import (
     SkillError,
     UpstreamUnavailable,
 )
-from petbot.domain.input import CommandInput, Input, TextInput
+from petbot.domain.input import CommandInput, Input, Role, TextInput, Turn
 from petbot.domain.ports import (
     Notifier,
     StylePort,
@@ -40,6 +40,7 @@ __all__ = [
     "Notifier",
     "Platform",
     "Process",
+    "Role",
     "Skill",
     "SkillContext",
     "SkillError",
@@ -47,6 +48,7 @@ __all__ = [
     "StylePort",
     "TextInput",
     "TrackFinishedCallback",
+    "Turn",
     "UpstreamUnavailable",
     "User",
     "VoicePort",

--- a/src/petbot/domain/input.py
+++ b/src/petbot/domain/input.py
@@ -14,6 +14,7 @@ re-hydrate the right member from a wire payload.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Annotated, Literal
 
 from pydantic import Field
@@ -21,11 +22,42 @@ from pydantic import Field
 from petbot.domain._model import Frozen
 
 
+class Role(StrEnum):
+    """Who spoke a :class:`Turn` — the structural position in the conversation.
+
+    Neutral and platform-agnostic (it maps onto the user/assistant split every chat
+    model uses); the speaker's *name* lives on :attr:`Turn.author`, not here.
+    """
+
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
+class Turn(Frozen):
+    """One prior message in the conversation a :class:`TextInput` continues.
+
+    ``author`` is the speaker's display name (a user's, or — for an assistant turn —
+    PetBot's own); ``text`` is what was said. An image-only bot reply is flattened to a
+    faithful text description by the frontend, so ``text`` is never structured data.
+    """
+
+    role: Role
+    author: str
+    text: str
+
+
 class TextInput(Frozen):
-    """Free-text conversational input (an ``@mention``). The process interprets it."""
+    """Free-text conversational input (an ``@mention``). The process interprets it.
+
+    ``history`` is the prior turns of the conversation this message continues (the
+    reply chain, oldest-first), reconstructed by the frontend; empty for a fresh
+    @mention. It rides on the conversational variant — never on ``CommandInput`` — so a
+    command can't carry chat history.
+    """
 
     kind: Literal["text"] = "text"
     text: str
+    history: tuple[Turn, ...] = ()
 
 
 class CommandInput(Frozen):

--- a/src/petbot/frontends/discord/bot.py
+++ b/src/petbot/frontends/discord/bot.py
@@ -21,7 +21,7 @@ from discord.ext import commands
 
 from petbot.domain import Process, SkillResult, TextInput, Turn
 from petbot.frontends.discord.context import build_context
-from petbot.frontends.discord.history import reconstruct
+from petbot.frontends.discord.history import reconstruct, resolve_parent
 from petbot.frontends.discord.render import SERVICE_UNREACHABLE, respond
 from petbot.frontends.discord.settings import DiscordSettings, HttpService, LambdaService
 from petbot.frontends.discord.slash import build_commands
@@ -88,42 +88,31 @@ class PetBot(commands.Bot):
     async def on_message(self, message: discord.Message) -> None:
         # Conversational entry: an @mention, OR a reply to one of PetBot's own messages
         # (so a follow-up needs no re-mention). Other bots and our own messages are ignored.
+        # The reply parent is resolved once here and reused for both the trigger test and
+        # the history walk, so the immediate parent is never fetched twice.
         if message.author.bot or self.user is None:
             return
         bot_user_id = self.user.id
-        if self.user not in message.mentions and not await self._is_reply_to_self(
-            message, bot_user_id
-        ):
+        parent = await resolve_parent(message)
+        replying_to_self = parent is not None and parent.author.id == bot_user_id
+        if self.user not in message.mentions and not replying_to_self:
             return
         text = _without_mention(message.content, bot_user_id).strip()
         if not text:
             return
-        history = await self._history_for(message, bot_user_id)
+        history = await self._history_for(parent, bot_user_id)
         await respond(
             message.channel, await self._respond(text, message, history), reference=message
         )
 
-    async def _is_reply_to_self(self, message: discord.Message, bot_user_id: int) -> bool:
-        """True if ``message`` is a reply to one of PetBot's own messages."""
-        ref = message.reference
-        if ref is None or ref.message_id is None:
-            return False
-        resolved = ref.resolved
-        if isinstance(resolved, discord.Message):
-            return resolved.author.id == bot_user_id
-        if isinstance(resolved, discord.DeletedReferencedMessage):
-            return False
-        try:
-            parent = await message.channel.fetch_message(ref.message_id)
-        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-            return False
-        return parent.author.id == bot_user_id
-
-    async def _history_for(self, message: discord.Message, bot_user_id: int) -> tuple[Turn, ...]:
-        """Reconstruct the reply-chain history, degrading to none on any failure."""
+    async def _history_for(
+        self, parent: discord.Message | None, bot_user_id: int
+    ) -> tuple[Turn, ...]:
+        """Reconstruct the reply-chain history from the resolved ``parent``, degrading to
+        none on any failure."""
         try:
             return await reconstruct(
-                message,
+                parent,
                 bot_user_id=bot_user_id,
                 max_turns=self.settings.history_max_turns,
                 strip_mention=_without_mention,

--- a/src/petbot/frontends/discord/bot.py
+++ b/src/petbot/frontends/discord/bot.py
@@ -19,8 +19,9 @@ import discord
 import httpx
 from discord.ext import commands
 
-from petbot.domain import Process, SkillResult, TextInput
+from petbot.domain import Process, SkillResult, TextInput, Turn
 from petbot.frontends.discord.context import build_context
+from petbot.frontends.discord.history import reconstruct
 from petbot.frontends.discord.render import SERVICE_UNREACHABLE, respond
 from petbot.frontends.discord.settings import DiscordSettings, HttpService, LambdaService
 from petbot.frontends.discord.slash import build_commands
@@ -85,22 +86,66 @@ class PetBot(commands.Bot):
             logger.info("Logged in as %s (discord.py %s).", self.user, discord.__version__)
 
     async def on_message(self, message: discord.Message) -> None:
-        if message.author.bot or self.user is None or self.user not in message.mentions:
+        # Conversational entry: an @mention, OR a reply to one of PetBot's own messages
+        # (so a follow-up needs no re-mention). Other bots and our own messages are ignored.
+        if message.author.bot or self.user is None:
             return
-        text = _without_mention(message.content, self.user.id).strip()
+        bot_user_id = self.user.id
+        if self.user not in message.mentions and not await self._is_reply_to_self(
+            message, bot_user_id
+        ):
+            return
+        text = _without_mention(message.content, bot_user_id).strip()
         if not text:
             return
-        await respond(message.channel, await self._respond(text, message))
+        history = await self._history_for(message, bot_user_id)
+        await respond(
+            message.channel, await self._respond(text, message, history), reference=message
+        )
 
-    async def _respond(self, text: str, message: discord.Message) -> SkillResult:
-        """Dispatch the @mention, mapping any transport failure to a friendly result.
+    async def _is_reply_to_self(self, message: discord.Message, bot_user_id: int) -> bool:
+        """True if ``message`` is a reply to one of PetBot's own messages."""
+        ref = message.reference
+        if ref is None or ref.message_id is None:
+            return False
+        resolved = ref.resolved
+        if isinstance(resolved, discord.Message):
+            return resolved.author.id == bot_user_id
+        if isinstance(resolved, discord.DeletedReferencedMessage):
+            return False
+        try:
+            parent = await message.channel.fetch_message(ref.message_id)
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            return False
+        return parent.author.id == bot_user_id
+
+    async def _history_for(self, message: discord.Message, bot_user_id: int) -> tuple[Turn, ...]:
+        """Reconstruct the reply-chain history, degrading to none on any failure."""
+        try:
+            return await reconstruct(
+                message,
+                bot_user_id=bot_user_id,
+                max_turns=self.settings.history_max_turns,
+                strip_mention=_without_mention,
+            )
+        except Exception:
+            logger.exception("history reconstruction failed; continuing without it")
+            return ()
+
+    async def _respond(
+        self, text: str, message: discord.Message, history: tuple[Turn, ...] = ()
+    ) -> SkillResult:
+        """Dispatch the conversational turn, mapping any transport failure to a friendly
+        result.
 
         A transport failure is the one error the frontend renders itself: the styler is
         on the far side of the unreachable connection, so this fallback is static."""
         assert self.process is not None
         try:
             async with message.channel.typing():
-                return await self.process.respond(TextInput(text=text), build_context(message))
+                return await self.process.respond(
+                    TextInput(text=text, history=history), build_context(message)
+                )
         except Exception:
             logger.exception("dispatch failed")
             return SkillResult.message(SERVICE_UNREACHABLE)

--- a/src/petbot/frontends/discord/history.py
+++ b/src/petbot/frontends/discord/history.py
@@ -1,0 +1,119 @@
+"""Reconstruct a conversation's history from the Discord reply chain.
+
+The frontend is the only place that holds the gateway, so it is the only place that can
+walk ``message.reference`` to recover the turns a reply continues. This maps that chain
+onto neutral :class:`~petbot.domain.input.Turn` values for ``TextInput.history`` — the
+driving-adapter half of "map a platform event to a complete ``Input``".
+
+Two parts: an async :func:`walk_reply_chain` that does the Discord I/O (bounded, and
+tolerant of deleted/unreadable ancestors), and a pure :func:`to_turns` that maps the
+gathered raw turns to neutral ones. The history is shipped *faithful and untrimmed* — an
+over-long conversation is handled compute-side (reactively), not here. An image-only bot
+card is flattened to a faithful text description (its real title + image URL), since an
+assistant turn can only be text in the model's history.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import discord
+
+from petbot.domain import Role, Turn
+
+
+@dataclass(frozen=True, slots=True)
+class RawTurn:
+    """One ancestor message, read off Discord, before neutral mapping."""
+
+    display_name: str
+    is_self: bool
+    text: str
+
+
+def _describe_card(embed: discord.Embed) -> str:
+    """A faithful one-line description of an embed (title + image URL), or ``""``."""
+    parts = [part for part in (embed.title, embed.image.url) if part]
+    return f"[image] {' — '.join(parts)}" if parts else ""
+
+
+def _message_text(message: discord.Message) -> str:
+    """A message's text: its content, else a description of its first usable embed."""
+    if message.content:
+        return message.content
+    for embed in message.embeds:
+        described = _describe_card(embed)
+        if described:
+            return described
+    return ""
+
+
+async def walk_reply_chain(
+    message: discord.Message, *, bot_user_id: int, max_turns: int
+) -> list[RawTurn]:
+    """Walk ``message``'s reply ancestors (newest-first), up to ``max_turns``.
+
+    Excludes ``message`` itself (it is the current prompt). Stops — without raising — at
+    the chain's end, a deleted ancestor, or one that can't be fetched.
+    """
+    channel = message.channel
+    raw: list[RawTurn] = []
+    current = message
+    for _ in range(max_turns):
+        ref = current.reference
+        if ref is None or ref.message_id is None:
+            break
+        resolved = ref.resolved
+        if isinstance(resolved, discord.Message):
+            parent = resolved
+        elif isinstance(resolved, discord.DeletedReferencedMessage):
+            break
+        else:
+            try:
+                parent = await channel.fetch_message(ref.message_id)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                break
+        raw.append(
+            RawTurn(
+                display_name=parent.author.display_name,
+                is_self=parent.author.id == bot_user_id,
+                text=_message_text(parent),
+            )
+        )
+        current = parent
+    return raw
+
+
+def to_turns(
+    raw: list[RawTurn],
+    *,
+    bot_user_id: int,
+    strip_mention: Callable[[str, int], str],
+) -> tuple[Turn, ...]:
+    """Map gathered raw turns (newest-first) to neutral turns (oldest-first).
+
+    A turn PetBot authored is an assistant turn; everything else is a user turn, with the
+    bot's own mention stripped (``strip_mention``). Empty turns are dropped.
+    """
+    turns: list[Turn] = []
+    for entry in reversed(raw):
+        if entry.is_self:
+            role, text = Role.ASSISTANT, entry.text.strip()
+        else:
+            role, text = Role.USER, strip_mention(entry.text, bot_user_id).strip()
+        if text:
+            turns.append(Turn(role=role, author=entry.display_name, text=text))
+    return tuple(turns)
+
+
+async def reconstruct(
+    message: discord.Message,
+    *,
+    bot_user_id: int,
+    max_turns: int,
+    strip_mention: Callable[[str, int], str],
+) -> tuple[Turn, ...]:
+    """Walk the reply chain and map it to neutral history (oldest-first)."""
+    raw = await walk_reply_chain(message, bot_user_id=bot_user_id, max_turns=max_turns)
+    return to_turns(raw, bot_user_id=bot_user_id, strip_mention=strip_mention)

--- a/src/petbot/frontends/discord/history.py
+++ b/src/petbot/frontends/discord/history.py
@@ -5,9 +5,11 @@ walk ``message.reference`` to recover the turns a reply continues. This maps tha
 onto neutral :class:`~petbot.domain.input.Turn` values for ``TextInput.history`` — the
 driving-adapter half of "map a platform event to a complete ``Input``".
 
-Two parts: an async :func:`walk_reply_chain` that does the Discord I/O (bounded, and
-tolerant of deleted/unreadable ancestors), and a pure :func:`to_turns` that maps the
-gathered raw turns to neutral ones. The history is shipped *faithful and untrimmed* — an
+Three parts: :func:`resolve_parent` (one message → the message it replies to, preferring
+a copy Discord already gave us over a REST fetch), an async :func:`walk_reply_chain` that
+follows it up the chain (bounded, tolerant of deleted/unreadable ancestors), and a pure
+:func:`to_turns` that maps the gathered raw turns to neutral ones. The history is shipped
+*faithful and untrimmed* — an
 over-long conversation is handled compute-side (reactively), not here. An image-only bot
 card is flattened to a faithful text description (its real title + image URL), since an
 assistant turn can only be text in the model's history.
@@ -49,39 +51,47 @@ def _message_text(message: discord.Message) -> str:
     return ""
 
 
-async def walk_reply_chain(
-    message: discord.Message, *, bot_user_id: int, max_turns: int
-) -> list[RawTurn]:
-    """Walk ``message``'s reply ancestors (newest-first), up to ``max_turns``.
+async def resolve_parent(message: discord.Message) -> discord.Message | None:
+    """The message ``message`` replies to, or ``None`` if it isn't a reply (or the parent
+    was deleted / can't be read).
 
-    Excludes ``message`` itself (it is the current prompt). Stops — without raising — at
-    the chain's end, a deleted ancestor, or one that can't be fetched.
+    Prefers a copy Discord already handed us — inline ``resolved``, then ``cached_message``
+    — and only pays for a REST ``fetch_message`` when neither has it.
     """
-    channel = message.channel
+    ref = message.reference
+    if ref is None or ref.message_id is None:
+        return None
+    if isinstance(ref.resolved, discord.DeletedReferencedMessage):
+        return None
+    free = ref.resolved if isinstance(ref.resolved, discord.Message) else ref.cached_message
+    if free is not None:
+        return free
+    try:
+        return await message.channel.fetch_message(ref.message_id)
+    except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+        return None
+
+
+async def walk_reply_chain(
+    parent: discord.Message | None, *, bot_user_id: int, max_turns: int
+) -> list[RawTurn]:
+    """Walk the reply chain from ``parent`` upward (newest-first), up to ``max_turns``.
+
+    ``parent`` is the message the current one replies to (``None`` when it isn't a reply),
+    already resolved by the caller so the immediate parent is fetched only once. Stops —
+    without raising — at the chain's end, a deleted ancestor, or one that can't be fetched.
+    """
     raw: list[RawTurn] = []
-    current = message
-    for _ in range(max_turns):
-        ref = current.reference
-        if ref is None or ref.message_id is None:
-            break
-        resolved = ref.resolved
-        if isinstance(resolved, discord.Message):
-            parent = resolved
-        elif isinstance(resolved, discord.DeletedReferencedMessage):
-            break
-        else:
-            try:
-                parent = await channel.fetch_message(ref.message_id)
-            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-                break
+    current = parent
+    while current is not None and len(raw) < max_turns:
         raw.append(
             RawTurn(
-                display_name=parent.author.display_name,
-                is_self=parent.author.id == bot_user_id,
-                text=_message_text(parent),
+                display_name=current.author.display_name,
+                is_self=current.author.id == bot_user_id,
+                text=_message_text(current),
             )
         )
-        current = parent
+        current = await resolve_parent(current)
     return raw
 
 
@@ -108,12 +118,12 @@ def to_turns(
 
 
 async def reconstruct(
-    message: discord.Message,
+    parent: discord.Message | None,
     *,
     bot_user_id: int,
     max_turns: int,
     strip_mention: Callable[[str, int], str],
 ) -> tuple[Turn, ...]:
-    """Walk the reply chain and map it to neutral history (oldest-first)."""
-    raw = await walk_reply_chain(message, bot_user_id=bot_user_id, max_turns=max_turns)
+    """Walk the reply chain from ``parent`` and map it to neutral history (oldest-first)."""
+    raw = await walk_reply_chain(parent, bot_user_id=bot_user_id, max_turns=max_turns)
     return to_turns(raw, bot_user_id=bot_user_id, strip_mention=strip_mention)

--- a/src/petbot/frontends/discord/history.py
+++ b/src/petbot/frontends/discord/history.py
@@ -8,7 +8,7 @@ driving-adapter half of "map a platform event to a complete ``Input``".
 Three parts: :func:`resolve_parent` (one message → the message it replies to, preferring
 a copy Discord already gave us over a REST fetch), an async :func:`walk_reply_chain` that
 follows it up the chain (bounded, tolerant of deleted/unreadable ancestors), and a pure
-:func:`to_turns` that maps the gathered raw turns to neutral ones. The history is shipped
+:func:`to_turns` that maps the gathered Discord turns to neutral ones. The history is shipped
 *faithful and untrimmed* — an
 over-long conversation is handled compute-side (reactively), not here. An image-only bot
 card is flattened to a faithful text description (its real title + image URL), since an
@@ -26,7 +26,7 @@ from petbot.domain import Role, Turn
 
 
 @dataclass(frozen=True, slots=True)
-class RawTurn:
+class DiscordTurn:
     """One ancestor message, read off Discord, before neutral mapping."""
 
     display_name: str
@@ -74,18 +74,18 @@ async def resolve_parent(message: discord.Message) -> discord.Message | None:
 
 async def walk_reply_chain(
     parent: discord.Message | None, *, bot_user_id: int, max_turns: int
-) -> list[RawTurn]:
+) -> list[DiscordTurn]:
     """Walk the reply chain from ``parent`` upward (newest-first), up to ``max_turns``.
 
     ``parent`` is the message the current one replies to (``None`` when it isn't a reply),
     already resolved by the caller so the immediate parent is fetched only once. Stops —
     without raising — at the chain's end, a deleted ancestor, or one that can't be fetched.
     """
-    raw: list[RawTurn] = []
+    raw: list[DiscordTurn] = []
     current = parent
     while current is not None and len(raw) < max_turns:
         raw.append(
-            RawTurn(
+            DiscordTurn(
                 display_name=current.author.display_name,
                 is_self=current.author.id == bot_user_id,
                 text=_message_text(current),
@@ -96,12 +96,12 @@ async def walk_reply_chain(
 
 
 def to_turns(
-    raw: list[RawTurn],
+    raw: list[DiscordTurn],
     *,
     bot_user_id: int,
     strip_mention: Callable[[str, int], str],
 ) -> tuple[Turn, ...]:
-    """Map gathered raw turns (newest-first) to neutral turns (oldest-first).
+    """Map gathered Discord turns (newest-first) to neutral turns (oldest-first).
 
     A turn PetBot authored is an assistant turn; everything else is a user turn, with the
     bot's own mention stripped (``strip_mention``). Empty turns are dropped.

--- a/src/petbot/frontends/discord/render.py
+++ b/src/petbot/frontends/discord/render.py
@@ -55,25 +55,38 @@ async def _send(
     sender: Callable[..., Awaitable[object]],
     content: str | None,
     embed: discord.Embed | None,
+    **extra: object,
 ) -> None:
     # Pass `embed` only when present so the call matches discord.py's non-optional
-    # `embed` overload (a None embed must never reach the gateway).
+    # `embed` overload (a None embed must never reach the gateway). `extra` carries the
+    # reply-threading kwargs, on the first chunk only.
     if embed is None:
-        await sender(content=content)
+        await sender(content=content, **extra)
     elif content is None:
-        await sender(embed=embed)
+        await sender(embed=embed, **extra)
     else:
-        await sender(content=content, embed=embed)
+        await sender(content=content, embed=embed, **extra)
 
 
-async def respond(channel: discord.abc.Messageable, result: SkillResult) -> None:
+async def respond(
+    channel: discord.abc.Messageable,
+    result: SkillResult,
+    *,
+    reference: discord.Message | discord.MessageReference | None = None,
+) -> None:
     """Send ``result`` to ``channel`` (the @mention path).
 
-    Expected failures render as a plain message; successes send the text (chunked)
-    and, on the first message, the embed.
+    Expected failures render as a plain message; successes send the text (chunked) and,
+    on the first message, the embed. When ``reference`` is given, the first message is a
+    reply to it (``mention_author=False`` — an anchor, not a re-ping every turn).
     """
-    for content, embed in _plan(result):
-        await _send(channel.send, content, embed)
+    for index, (content, embed) in enumerate(_plan(result)):
+        extra: dict[str, object] = (
+            {"reference": reference, "mention_author": False}
+            if index == 0 and reference is not None
+            else {}
+        )
+        await _send(channel.send, content, embed, **extra)
 
 
 async def respond_interaction(interaction: discord.Interaction, result: SkillResult) -> None:

--- a/src/petbot/frontends/discord/settings.py
+++ b/src/petbot/frontends/discord/settings.py
@@ -46,6 +46,9 @@ class DiscordSettings(BaseSettings):
     discord_token: str
     dev_guild_id: int | None = None
     log_level: str = "INFO"
+    #: How many reply-chain ancestors to fetch when reconstructing conversation history
+    #: (a Discord-API cost bound, not a model-context bound). Env ``HISTORY_MAX_TURNS``.
+    history_max_turns: int = 25
     #: The compute service to dispatch to (required; see ``SERVICE__*``).
     service: ServiceTarget
 

--- a/src/petbot/process/chat.py
+++ b/src/petbot/process/chat.py
@@ -25,7 +25,7 @@ from petbot.process.context import (
     build_compactor,
     is_context_overflow,
 )
-from petbot.process.history import to_model_messages
+from petbot.process.history import drop_leading_assistant, to_model_messages
 from petbot.process.model import build_model
 from petbot.process.settings import ChatSettings
 from petbot.process.voice import PassthroughStyle
@@ -95,7 +95,7 @@ class ChatProcess(Process):
             except ModelHTTPError as exc:
                 if not is_context_overflow(exc) or attempt == MAX_COMPACTION_RETRIES:
                     raise
-                compacted = await self._compactor.compact(history)
+                compacted = drop_leading_assistant(await self._compactor.compact(history))
                 if len(compacted) >= len(history):
                     raise  # can't shrink further — give up rather than loop forever
                 history = compacted

--- a/src/petbot/process/chat.py
+++ b/src/petbot/process/chat.py
@@ -11,11 +11,21 @@ styling stays uniform across processes without a second LLM pass.
 
 from __future__ import annotations
 
+from pydantic_ai import AgentRunResult
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models import Model
 
 from petbot.domain import Input, Process, SkillContext, SkillResult, StylePort, TextInput
 from petbot.platform import ToolRegistry
 from petbot.process.agent import ChatDeps, build_agent
+from petbot.process.context import (
+    MAX_COMPACTION_RETRIES,
+    Compactor,
+    build_compactor,
+    is_context_overflow,
+)
+from petbot.process.history import to_model_messages
 from petbot.process.model import build_model
 from petbot.process.settings import ChatSettings
 from petbot.process.voice import PassthroughStyle
@@ -44,6 +54,7 @@ class ChatProcess(Process):
         self._model = model
         self._style: StylePort = style or PassthroughStyle()
         self._agent = build_agent(self._settings.system_prompt)
+        self._compactor: Compactor = build_compactor(self._settings, model=model)
 
     def _resolved_model(self) -> Model | str:
         if self._model is None:
@@ -55,7 +66,7 @@ class ChatProcess(Process):
             # The router only sends conversational input here; guard for type-safety.
             raise TypeError(f"ChatProcess received {type(inp).__name__}")
         deps = ChatDeps(registry=self._registry, ctx=ctx)
-        result = await self._agent.run(inp.text, deps=deps, model=self._resolved_model())
+        result = await self._run(inp.text, to_model_messages(inp.history), deps)
         card = next((a for a in deps.attachments if a.embed is not None), None)
         files = tuple(f for a in deps.attachments for f in a.files)
         out = SkillResult.message(
@@ -64,3 +75,28 @@ class ChatProcess(Process):
             files=files,
         )
         return await self._style.stylize(out, ctx)
+
+    async def _run(
+        self, prompt: str, history: list[ModelMessage], deps: ChatDeps
+    ) -> AgentRunResult[str]:
+        """Run the agent, reactively compacting ``history`` if the model rejects it for
+        length — the model's real window is the trigger, so we never guess a budget.
+
+        On an overflow we compact and retry, up to :data:`MAX_COMPACTION_RETRIES` or until
+        the history can no longer shrink; any other error (or a still-overflowing,
+        un-shrinkable history) propagates to :func:`~petbot.platform.serve.serve`.
+        """
+        model = self._resolved_model()
+        for attempt in range(MAX_COMPACTION_RETRIES + 1):
+            try:
+                return await self._agent.run(
+                    prompt, message_history=history, deps=deps, model=model
+                )
+            except ModelHTTPError as exc:
+                if not is_context_overflow(exc) or attempt == MAX_COMPACTION_RETRIES:
+                    raise
+                compacted = await self._compactor.compact(history)
+                if len(compacted) >= len(history):
+                    raise  # can't shrink further — give up rather than loop forever
+                history = compacted
+        raise AssertionError("unreachable: the loop returns or raises")  # pragma: no cover

--- a/src/petbot/process/context.py
+++ b/src/petbot/process/context.py
@@ -1,0 +1,139 @@
+"""Reactive context-window handling: compact history only when the model rejects it.
+
+pydantic-ai does not expose a model's context-window *size*
+(https://redirect.github.com/pydantic/pydantic-ai/issues/4538), so PetBot does **not**
+guess a token budget — a budget constant would be wrong the moment the configured model
+is swapped. Instead the *provider* is the trigger: a run is attempted, and only if it
+fails for length (:func:`is_context_overflow`) does the chat process compact the message
+history and retry.
+
+The strategy is dependency-injected from :class:`~petbot.process.settings.ChatSettings`
+via :func:`build_compactor` (a config ``match``, like
+:func:`~petbot.process.model.build_model_from_config`): a :class:`SlidingWindow` (drop the
+oldest half, zero cost) or a :class:`Summarizer` (one small-LLM pass over the oldest
+half). Proactive, precise budgeting can drop in behind the same seam once the window size
+is exposed upstream.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, assert_never
+
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+from pydantic_ai.models import Model
+
+from petbot.process.model import build_model_from_config
+from petbot.process.settings import (
+    ChatSettings,
+    SlidingWindowContext,
+    SummarizeContext,
+)
+
+#: How many times to compact-and-retry before giving up on an over-long conversation.
+MAX_COMPACTION_RETRIES = 3
+
+#: HTTP statuses a provider uses to reject an over-long request.
+_OVERFLOW_STATUS = frozenset({400, 413})
+#: Phrases providers put in the body of a context-length rejection (lower-cased).
+_OVERFLOW_PHRASES = (
+    "context length",
+    "context window",
+    "maximum context",
+    "too long",
+    "too many tokens",
+    "reduce the length",
+    "string too long",
+)
+
+_SUMMARIZE_INSTRUCTIONS = (
+    "Summarise the earlier conversation concisely for use as context in an ongoing chat. "
+    "Preserve facts, names, decisions, and anything the user might refer back to; omit "
+    "small talk. Write the summary as plain notes, not a reply."
+)
+
+
+def is_context_overflow(exc: Exception) -> bool:
+    """Best-effort: does ``exc`` look like a provider rejecting an over-long request?
+
+    Provider-specific — pydantic-ai surfaces it as a :class:`ModelHTTPError` with no
+    typed "context length exceeded", so we match a 400/413 whose text names a length
+    limit. A false negative just means we don't retry; a false positive costs one
+    needless compaction.
+    """
+    if not isinstance(exc, ModelHTTPError) or exc.status_code not in _OVERFLOW_STATUS:
+        return False
+    text = str(exc).lower()
+    return any(phrase in text for phrase in _OVERFLOW_PHRASES)
+
+
+class Compactor(Protocol):
+    """Shrinks an over-long message history so a retried run can fit."""
+
+    async def compact(self, messages: list[ModelMessage]) -> list[ModelMessage]:
+        """Return a shorter history; return it unchanged if it can't be shortened."""
+        ...
+
+
+class SlidingWindow:
+    """Drop the oldest half of the history. Zero cost — old turns are simply forgotten."""
+
+    async def compact(self, messages: list[ModelMessage]) -> list[ModelMessage]:
+        if len(messages) <= 1:
+            return messages
+        return messages[len(messages) // 2 :]
+
+
+class Summarizer:
+    """Replace the oldest half of the history with a small-LLM summary of it.
+
+    Mirrors the :class:`~petbot.process.voice.Stylist` pattern: a small, tool-less agent
+    whose model is the cheaper stylizer tier (:meth:`ChatSettings.stylizer_llm`), built
+    lazily so construction stays offline and a ``TestModel`` can be injected.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: ChatSettings | None = None,
+        model: Model | str | None = None,
+    ) -> None:
+        self._settings = settings or ChatSettings()
+        self._model = model
+        self._agent: Agent[None, str] = Agent(output_type=str, instructions=_SUMMARIZE_INSTRUCTIONS)
+
+    def _resolved_model(self) -> Model | str:
+        if self._model is None:
+            self._model = build_model_from_config(self._settings.stylizer_llm())
+        return self._model
+
+    async def compact(self, messages: list[ModelMessage]) -> list[ModelMessage]:
+        if len(messages) <= 2:
+            return messages
+        split = len(messages) // 2
+        older, recent = messages[:split], messages[split:]
+        summary = await self._agent.run(message_history=older, model=self._resolved_model())
+        note = ModelRequest(
+            parts=[UserPromptPart(content=f"[Summary of earlier conversation]\n{summary.output}")]
+        )
+        return [note, *recent]
+
+
+def build_compactor(
+    settings: ChatSettings,
+    *,
+    model: Model | str | None = None,
+) -> Compactor:
+    """Build the configured compaction strategy (a config ``match``, like the model).
+
+    ``model`` is forwarded to the summarizer (``None`` ⇒ it lazily builds the stylizer
+    tier); the sliding window ignores it.
+    """
+    match settings.context:
+        case SlidingWindowContext():
+            return SlidingWindow()
+        case SummarizeContext():
+            return Summarizer(settings=settings, model=model)
+        case _:
+            assert_never(settings.context)

--- a/src/petbot/process/history.py
+++ b/src/petbot/process/history.py
@@ -8,6 +8,7 @@ handled reactively in :mod:`petbot.process.context`, not by trimming here).
 
 from __future__ import annotations
 
+from itertools import groupby
 from typing import assert_never
 
 from pydantic_ai.messages import (
@@ -33,28 +34,33 @@ def _content(turn: Turn) -> str:
     return f"{turn.author}: {text}" if turn.role is Role.USER else text
 
 
+def drop_leading_assistant(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Drop leading assistant messages so the history starts with a user message —
+    providers reject an assistant-first run.
+
+    Applied to a freshly-mapped history and again to a *compacted* one, since compaction
+    can slice the leading user message off the front.
+    """
+    first_user = next(
+        (i for i, message in enumerate(messages) if isinstance(message, ModelRequest)),
+        len(messages),
+    )
+    return messages[first_user:]
+
+
 def to_model_messages(history: tuple[Turn, ...]) -> list[ModelMessage]:
     """Turn the neutral ``history`` into pydantic-ai ``message_history``.
 
-    Empty turns are dropped, then consecutive same-role turns are merged into one
-    message (most chat backends reject a run of two user or two assistant messages, and
-    a multi-user chain produces them), then each is mapped by an exhaustive role match.
+    Empty turns are dropped; consecutive same-role turns are merged (a multi-user chain
+    produces them, and most backends reject a run of two of the same role); each is mapped
+    by a role match; and any leading assistant message is dropped (the history must start
+    with a user message).
     """
-    pairs: list[tuple[Role, str]] = []
-    for turn in history:
-        content = _content(turn)
-        if content:
-            pairs.append((turn.role, content))
-
-    merged: list[tuple[Role, str]] = []
-    for role, content in pairs:
-        if merged and merged[-1][0] == role:
-            merged[-1] = (role, f"{merged[-1][1]}\n{content}")
-        else:
-            merged.append((role, content))
+    pairs = [(turn.role, content) for turn in history if (content := _content(turn))]
 
     messages: list[ModelMessage] = []
-    for role, content in merged:
+    for role, group in groupby(pairs, key=lambda pair: pair[0]):
+        content = "\n".join(text for _, text in group)
         match role:
             case Role.USER:
                 messages.append(ModelRequest(parts=[UserPromptPart(content=content)]))
@@ -62,4 +68,4 @@ def to_model_messages(history: tuple[Turn, ...]) -> list[ModelMessage]:
                 messages.append(ModelResponse(parts=[TextPart(content=content)]))
             case _:
                 assert_never(role)
-    return messages
+    return drop_leading_assistant(messages)

--- a/src/petbot/process/history.py
+++ b/src/petbot/process/history.py
@@ -1,0 +1,65 @@
+"""Map the neutral reply-chain history onto pydantic-ai message history.
+
+The one place a conversation's prior turns — neutral :class:`~petbot.domain.input.Turn`
+values, reconstructed frontend-side from the Discord reply chain — become model input. A
+**pure** mapping: no model, no I/O, and no window management (an over-long history is
+handled reactively in :mod:`petbot.process.context`, not by trimming here).
+"""
+
+from __future__ import annotations
+
+from typing import assert_never
+
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from petbot.domain import Role, Turn
+
+
+def _content(turn: Turn) -> str:
+    """The text a turn contributes, or ``""`` if it contributes nothing.
+
+    A user turn is prefixed with its author so the model can attribute it in a
+    multi-user chain; an assistant turn is not (the model owns its own replies).
+    """
+    text = turn.text.strip()
+    if not text:
+        return ""
+    return f"{turn.author}: {text}" if turn.role is Role.USER else text
+
+
+def to_model_messages(history: tuple[Turn, ...]) -> list[ModelMessage]:
+    """Turn the neutral ``history`` into pydantic-ai ``message_history``.
+
+    Empty turns are dropped, then consecutive same-role turns are merged into one
+    message (most chat backends reject a run of two user or two assistant messages, and
+    a multi-user chain produces them), then each is mapped by an exhaustive role match.
+    """
+    pairs: list[tuple[Role, str]] = []
+    for turn in history:
+        content = _content(turn)
+        if content:
+            pairs.append((turn.role, content))
+
+    merged: list[tuple[Role, str]] = []
+    for role, content in pairs:
+        if merged and merged[-1][0] == role:
+            merged[-1] = (role, f"{merged[-1][1]}\n{content}")
+        else:
+            merged.append((role, content))
+
+    messages: list[ModelMessage] = []
+    for role, content in merged:
+        match role:
+            case Role.USER:
+                messages.append(ModelRequest(parts=[UserPromptPart(content=content)]))
+            case Role.ASSISTANT:
+                messages.append(ModelResponse(parts=[TextPart(content=content)]))
+            case _:
+                assert_never(role)
+    return messages

--- a/src/petbot/process/settings.py
+++ b/src/petbot/process/settings.py
@@ -83,6 +83,24 @@ LLMConfig = Annotated[
 ]
 
 
+class SlidingWindowContext(BaseModel):
+    """Compact an over-long history by dropping its oldest half. No LLM, no cost."""
+
+    kind: Literal["sliding_window"] = "sliding_window"
+
+
+class SummarizeContext(BaseModel):
+    """Compact an over-long history by summarising its oldest half with a small LLM."""
+
+    kind: Literal["summarize"] = "summarize"
+
+
+#: How the chat process compacts history *when the model rejects it for length* — the
+#: strategy is reactive (the provider is the trigger), so it carries no budget/window
+#: number. Tagged by ``kind`` (``CHAT_CONTEXT__KIND=summarize``).
+ContextConfig = Annotated[SlidingWindowContext | SummarizeContext, Field(discriminator="kind")]
+
+
 class ChatSettings(BaseSettings):
     """Which LLM(s) the chat skill talks to, and how to reach them."""
 
@@ -106,6 +124,9 @@ class ChatSettings(BaseSettings):
     #: The stylizer's persona + rewrite rule (``persona.md`` + ``stylizer.md``);
     #: override via ``CHAT_STYLIZER_PROMPT``.
     stylizer_prompt: str = Field(default_factory=_load_stylizer_prompt)
+    #: How to compact an over-long conversation when the model rejects it for length
+    #: (``CHAT_CONTEXT__KIND``); defaults to the zero-cost sliding window.
+    context: ContextConfig = Field(default_factory=SlidingWindowContext)
 
     def stylizer_llm(self) -> LLMConfig:
         """The stylizer's model config: its own if set, else the agent's (one tier)."""

--- a/tests/domain/test_domain.py
+++ b/tests/domain/test_domain.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
-from petbot.domain import EmbedSpec, Platform, SkillContext, SkillResult, User
+from petbot.domain import (
+    CommandInput,
+    EmbedSpec,
+    Input,
+    Platform,
+    Role,
+    SkillContext,
+    SkillResult,
+    TextInput,
+    Turn,
+    User,
+)
 
 
 def _ctx() -> SkillContext:
@@ -35,3 +46,22 @@ def test_models_are_frozen() -> None:
 def test_unknown_fields_rejected() -> None:
     with pytest.raises(ValidationError):
         SkillResult.model_validate({"text": "hi", "bogus": 1})
+
+
+def test_text_input_history_round_trips() -> None:
+    # History rides on the wire inside the Input sum type: dump to JSON-able data, then
+    # re-hydrate the right member by `kind` — tuple + Role enum + nested Turn survive.
+    inp = TextInput(
+        text="and another?",
+        history=(
+            Turn(role=Role.USER, author="Alice", text="show me a pony"),
+            Turn(role=Role.ASSISTANT, author="PetBot", text="here you go!"),
+        ),
+    )
+    adapter: TypeAdapter[Input] = TypeAdapter(Input)
+    assert adapter.validate_python(inp.model_dump(mode="json")) == inp
+
+
+def test_command_input_has_no_history() -> None:
+    # History is sum-type-local: only the conversational variant carries it.
+    assert "history" not in CommandInput.model_fields

--- a/tests/frontends/discord/test_history.py
+++ b/tests/frontends/discord/test_history.py
@@ -16,6 +16,7 @@ from petbot.frontends.discord.history import (
     RawTurn,
     _describe_card,
     reconstruct,
+    resolve_parent,
     to_turns,
     walk_reply_chain,
 )
@@ -34,9 +35,10 @@ class FakeAuthor:
 
 class FakeRef:
     def __init__(self, message_id: int | None) -> None:
-        # Always unresolved, so the walk goes through `fetch_message` (the general path).
+        # Always unresolved + uncached, so resolution goes through `fetch_message`.
         self.message_id = message_id
         self.resolved = None
+        self.cached_message = None
 
 
 class FakeChannel:
@@ -98,38 +100,57 @@ def test_describe_card_uses_title_and_image() -> None:
 # --- the walk -----------------------------------------------------------------
 
 
+async def test_resolve_parent_fetches_when_unresolved() -> None:
+    parent = FakeMessage(author=FakeAuthor(1, "PetBot"), content="here you go!")
+    trigger = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@1> another?", reference=FakeRef(100)
+    )
+    trigger.channel = FakeChannel({100: parent})
+    assert await resolve_parent(trigger) is parent  # type: ignore[arg-type, comparison-overlap]
+
+
+async def test_resolve_parent_is_none_without_a_reference() -> None:
+    msg = FakeMessage(author=FakeAuthor(2, "Alice"), content="hi")
+    assert await resolve_parent(msg) is None  # type: ignore[arg-type]
+
+
+async def test_resolve_parent_is_none_when_unfetchable() -> None:
+    msg = FakeMessage(author=FakeAuthor(2, "Alice"), content="hi", reference=FakeRef(999))
+    msg.channel = FakeChannel({})  # 999 missing -> NotFound -> None, not raised
+    assert await resolve_parent(msg) is None  # type: ignore[arg-type]
+
+
 async def test_walk_collects_ancestors_newest_first() -> None:
     bot_msg = FakeMessage(author=FakeAuthor(1, "PetBot"), content="here you go!")
     user_msg = FakeMessage(
         author=FakeAuthor(2, "Alice"), content="<@1> show me a pony", reference=FakeRef(100)
     )
-    trigger = FakeMessage(
-        author=FakeAuthor(2, "Alice"), content="<@1> another?", reference=FakeRef(101)
-    )
-    channel = FakeChannel({100: bot_msg, 101: user_msg})
-    for msg in (bot_msg, user_msg, trigger):
+    channel = FakeChannel({100: bot_msg})
+    for msg in (bot_msg, user_msg):
         msg.channel = channel
 
-    raw = await walk_reply_chain(trigger, bot_user_id=1, max_turns=25)  # type: ignore[arg-type]
+    # The caller passes the already-resolved immediate parent (`user_msg`).
+    raw = await walk_reply_chain(user_msg, bot_user_id=1, max_turns=25)  # type: ignore[arg-type]
     assert [(r.display_name, r.is_self) for r in raw] == [("Alice", False), ("PetBot", True)]
 
 
 async def test_walk_respects_max_turns() -> None:
-    parent = FakeMessage(author=FakeAuthor(1, "PetBot"), content="oldest")
+    oldest = FakeMessage(author=FakeAuthor(1, "PetBot"), content="oldest")
     middle = FakeMessage(author=FakeAuthor(2, "Alice"), content="middle", reference=FakeRef(1))
-    trigger = FakeMessage(author=FakeAuthor(2, "Alice"), content="newest", reference=FakeRef(2))
-    channel = FakeChannel({1: parent, 2: middle})
-    for msg in (parent, middle, trigger):
+    channel = FakeChannel({1: oldest})
+    for msg in (oldest, middle):
         msg.channel = channel
 
-    raw = await walk_reply_chain(trigger, bot_user_id=1, max_turns=1)  # type: ignore[arg-type]
+    raw = await walk_reply_chain(middle, bot_user_id=1, max_turns=1)  # type: ignore[arg-type]
     assert len(raw) == 1 and raw[0].text == "middle"
 
 
 async def test_walk_stops_on_unfetchable_ancestor() -> None:
-    trigger = FakeMessage(author=FakeAuthor(2, "Alice"), content="hi", reference=FakeRef(999))
-    trigger.channel = FakeChannel({})  # 999 missing -> NotFound -> stop, not raise
-    assert await walk_reply_chain(trigger, bot_user_id=1, max_turns=25) == []  # type: ignore[arg-type]
+    # The parent is recorded; its own parent (999) is missing -> the walk stops, not raises.
+    parent = FakeMessage(author=FakeAuthor(1, "PetBot"), content="hi", reference=FakeRef(999))
+    parent.channel = FakeChannel({})
+    raw = await walk_reply_chain(parent, bot_user_id=1, max_turns=25)  # type: ignore[arg-type]
+    assert [r.text for r in raw] == ["hi"]
 
 
 # --- end to end ---------------------------------------------------------------
@@ -145,8 +166,9 @@ async def test_reconstruct_flattens_an_image_only_bot_card() -> None:
     channel = FakeChannel({100: bot_card})
     bot_card.channel = trigger.channel = channel
 
+    parent = await resolve_parent(trigger)  # type: ignore[arg-type]
     turns = await reconstruct(
-        trigger,  # type: ignore[arg-type]
+        parent,
         bot_user_id=1,
         max_turns=25,
         strip_mention=_without_mention,
@@ -158,8 +180,9 @@ async def test_reconstruct_flattens_an_image_only_bot_card() -> None:
 
 async def test_reconstruct_is_empty_without_a_reply() -> None:
     msg = FakeMessage(author=FakeAuthor(2, "Alice"), content="<@1> hi")
+    parent = await resolve_parent(msg)  # type: ignore[arg-type]
     turns = await reconstruct(
-        msg,  # type: ignore[arg-type]
+        parent,
         bot_user_id=1,
         max_turns=25,
         strip_mention=_without_mention,

--- a/tests/frontends/discord/test_history.py
+++ b/tests/frontends/discord/test_history.py
@@ -13,7 +13,7 @@ import discord
 from petbot.domain import Role, Turn
 from petbot.frontends.discord.bot import _without_mention
 from petbot.frontends.discord.history import (
-    RawTurn,
+    DiscordTurn,
     _describe_card,
     reconstruct,
     resolve_parent,
@@ -73,8 +73,8 @@ class FakeMessage:
 
 def test_to_turns_orders_oldest_first_and_maps_roles() -> None:
     raw = [  # walk yields newest-first
-        RawTurn(display_name="Alice", is_self=False, text="<@1> and another?"),
-        RawTurn(display_name="PetBot", is_self=True, text="here you go!"),
+        DiscordTurn(display_name="Alice", is_self=False, text="<@1> and another?"),
+        DiscordTurn(display_name="PetBot", is_self=True, text="here you go!"),
     ]
     assert to_turns(raw, bot_user_id=1, strip_mention=_without_mention) == (
         Turn(role=Role.ASSISTANT, author="PetBot", text="here you go!"),
@@ -84,8 +84,8 @@ def test_to_turns_orders_oldest_first_and_maps_roles() -> None:
 
 def test_to_turns_drops_turns_that_become_empty() -> None:
     raw = [
-        RawTurn(display_name="Alice", is_self=False, text="<@1>"),  # only a mention
-        RawTurn(display_name="PetBot", is_self=True, text="   "),
+        DiscordTurn(display_name="Alice", is_self=False, text="<@1>"),  # only a mention
+        DiscordTurn(display_name="PetBot", is_self=True, text="   "),
     ]
     assert to_turns(raw, bot_user_id=1, strip_mention=_without_mention) == ()
 

--- a/tests/frontends/discord/test_history.py
+++ b/tests/frontends/discord/test_history.py
@@ -1,0 +1,167 @@
+"""Reconstructing conversation history from the Discord reply chain.
+
+The pure mapping (`to_turns`) is tested directly; the walk is tested against fake
+messages whose parents are served through a fake channel's `fetch_message`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import discord
+
+from petbot.domain import Role, Turn
+from petbot.frontends.discord.bot import _without_mention
+from petbot.frontends.discord.history import (
+    RawTurn,
+    _describe_card,
+    reconstruct,
+    to_turns,
+    walk_reply_chain,
+)
+
+
+class _FakeResp:
+    status = 404
+    reason = "Not Found"
+
+
+class FakeAuthor:
+    def __init__(self, author_id: int, name: str) -> None:
+        self.id = author_id
+        self.display_name = name
+
+
+class FakeRef:
+    def __init__(self, message_id: int | None) -> None:
+        # Always unresolved, so the walk goes through `fetch_message` (the general path).
+        self.message_id = message_id
+        self.resolved = None
+
+
+class FakeChannel:
+    def __init__(self, fetch: Mapping[int, FakeMessage] | None = None) -> None:
+        self._fetch = dict(fetch or {})
+
+    async def fetch_message(self, message_id: int) -> FakeMessage:
+        if message_id not in self._fetch:
+            raise discord.NotFound(_FakeResp(), "missing")  # type: ignore[arg-type]
+        return self._fetch[message_id]
+
+
+class FakeMessage:
+    def __init__(
+        self,
+        *,
+        author: FakeAuthor,
+        content: str = "",
+        embeds: tuple[discord.Embed, ...] = (),
+        reference: FakeRef | None = None,
+        channel: FakeChannel | None = None,
+    ) -> None:
+        self.author = author
+        self.content = content
+        self.embeds = list(embeds)
+        self.reference = reference
+        self.channel = channel or FakeChannel()
+
+
+# --- the pure mapping ---------------------------------------------------------
+
+
+def test_to_turns_orders_oldest_first_and_maps_roles() -> None:
+    raw = [  # walk yields newest-first
+        RawTurn(display_name="Alice", is_self=False, text="<@1> and another?"),
+        RawTurn(display_name="PetBot", is_self=True, text="here you go!"),
+    ]
+    assert to_turns(raw, bot_user_id=1, strip_mention=_without_mention) == (
+        Turn(role=Role.ASSISTANT, author="PetBot", text="here you go!"),
+        Turn(role=Role.USER, author="Alice", text="and another?"),
+    )
+
+
+def test_to_turns_drops_turns_that_become_empty() -> None:
+    raw = [
+        RawTurn(display_name="Alice", is_self=False, text="<@1>"),  # only a mention
+        RawTurn(display_name="PetBot", is_self=True, text="   "),
+    ]
+    assert to_turns(raw, bot_user_id=1, strip_mention=_without_mention) == ()
+
+
+def test_describe_card_uses_title_and_image() -> None:
+    embed = discord.Embed(title="results")
+    embed.set_image(url="http://i/x.png")
+    assert _describe_card(embed) == "[image] results — http://i/x.png"
+    assert _describe_card(discord.Embed()) == ""
+
+
+# --- the walk -----------------------------------------------------------------
+
+
+async def test_walk_collects_ancestors_newest_first() -> None:
+    bot_msg = FakeMessage(author=FakeAuthor(1, "PetBot"), content="here you go!")
+    user_msg = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@1> show me a pony", reference=FakeRef(100)
+    )
+    trigger = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@1> another?", reference=FakeRef(101)
+    )
+    channel = FakeChannel({100: bot_msg, 101: user_msg})
+    for msg in (bot_msg, user_msg, trigger):
+        msg.channel = channel
+
+    raw = await walk_reply_chain(trigger, bot_user_id=1, max_turns=25)  # type: ignore[arg-type]
+    assert [(r.display_name, r.is_self) for r in raw] == [("Alice", False), ("PetBot", True)]
+
+
+async def test_walk_respects_max_turns() -> None:
+    parent = FakeMessage(author=FakeAuthor(1, "PetBot"), content="oldest")
+    middle = FakeMessage(author=FakeAuthor(2, "Alice"), content="middle", reference=FakeRef(1))
+    trigger = FakeMessage(author=FakeAuthor(2, "Alice"), content="newest", reference=FakeRef(2))
+    channel = FakeChannel({1: parent, 2: middle})
+    for msg in (parent, middle, trigger):
+        msg.channel = channel
+
+    raw = await walk_reply_chain(trigger, bot_user_id=1, max_turns=1)  # type: ignore[arg-type]
+    assert len(raw) == 1 and raw[0].text == "middle"
+
+
+async def test_walk_stops_on_unfetchable_ancestor() -> None:
+    trigger = FakeMessage(author=FakeAuthor(2, "Alice"), content="hi", reference=FakeRef(999))
+    trigger.channel = FakeChannel({})  # 999 missing -> NotFound -> stop, not raise
+    assert await walk_reply_chain(trigger, bot_user_id=1, max_turns=25) == []  # type: ignore[arg-type]
+
+
+# --- end to end ---------------------------------------------------------------
+
+
+async def test_reconstruct_flattens_an_image_only_bot_card() -> None:
+    card = discord.Embed(title="results")
+    card.set_image(url="http://i/x.png")
+    bot_card = FakeMessage(author=FakeAuthor(1, "PetBot"), content="", embeds=(card,))
+    trigger = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@1> another?", reference=FakeRef(100)
+    )
+    channel = FakeChannel({100: bot_card})
+    bot_card.channel = trigger.channel = channel
+
+    turns = await reconstruct(
+        trigger,  # type: ignore[arg-type]
+        bot_user_id=1,
+        max_turns=25,
+        strip_mention=_without_mention,
+    )
+    assert turns == (
+        Turn(role=Role.ASSISTANT, author="PetBot", text="[image] results — http://i/x.png"),
+    )
+
+
+async def test_reconstruct_is_empty_without_a_reply() -> None:
+    msg = FakeMessage(author=FakeAuthor(2, "Alice"), content="<@1> hi")
+    turns = await reconstruct(
+        msg,  # type: ignore[arg-type]
+        bot_user_id=1,
+        max_turns=25,
+        strip_mention=_without_mention,
+    )
+    assert turns == ()

--- a/tests/frontends/discord/test_render.py
+++ b/tests/frontends/discord/test_render.py
@@ -29,12 +29,21 @@ class FakeChannel:
         self.id = channel_id
         self._nsfw = nsfw
         self.sent: list[dict[str, object]] = []
+        self.kwargs: list[dict[str, object]] = []
 
     def is_nsfw(self) -> bool:
         return self._nsfw
 
-    async def send(self, content: str | None = None, embed: discord.Embed | None = None) -> None:
+    async def send(
+        self,
+        content: str | None = None,
+        embed: discord.Embed | None = None,
+        *,
+        reference: object = None,
+        mention_author: bool | None = None,
+    ) -> None:
         self.sent.append({"content": content, "embed": embed})
+        self.kwargs.append({"reference": reference, "mention_author": mention_author})
 
     @contextlib.asynccontextmanager
     async def typing(self) -> AsyncIterator[None]:
@@ -83,6 +92,15 @@ async def test_respond_chunks_long_text_embed_only_first() -> None:
     assert len(channel.sent) == len(chunk_text(long))
     assert channel.sent[0]["embed"] is not None
     assert channel.sent[1]["embed"] is None
+
+
+async def test_respond_threads_reply_on_first_chunk_only() -> None:
+    channel = FakeChannel()
+    parent = object()  # stands in for the triggering discord.Message
+    await respond(channel, SkillResult.message("x" * 4500), reference=parent)  # type: ignore[arg-type]
+    # First chunk replies to the parent without re-pinging; later chunks are plain.
+    assert channel.kwargs[0] == {"reference": parent, "mention_author": False}
+    assert channel.kwargs[1] == {"reference": None, "mention_author": None}
 
 
 def test_build_context_reads_nsfw_and_ids() -> None:

--- a/tests/process/test_process.py
+++ b/tests/process/test_process.py
@@ -41,7 +41,7 @@ from petbot.process.context import (
     build_compactor,
     is_context_overflow,
 )
-from petbot.process.history import to_model_messages
+from petbot.process.history import drop_leading_assistant, to_model_messages
 from petbot.process.model import build_model, build_model_from_config
 from petbot.process.settings import (
     BedrockModel,
@@ -300,11 +300,41 @@ def test_to_model_messages_merges_consecutive_same_role() -> None:
 def test_to_model_messages_drops_empty_turns() -> None:
     msgs = to_model_messages(
         (
-            Turn(role=Role.USER, author="Alice", text="   "),
-            Turn(role=Role.ASSISTANT, author="PetBot", text="hi"),
+            Turn(role=Role.USER, author="Alice", text="real"),
+            Turn(role=Role.ASSISTANT, author="PetBot", text="   "),  # empty -> dropped
         )
     )
-    assert _texts(msgs) == [("response", "hi")]
+    assert _texts(msgs) == [("request", "Alice: real")]
+
+
+def test_to_model_messages_drops_leading_assistant_turns() -> None:
+    # History must begin with a user message (providers reject an assistant-first run), so
+    # a leading bot turn is dropped.
+    msgs = to_model_messages(
+        (
+            Turn(role=Role.ASSISTANT, author="PetBot", text="earlier reply"),
+            Turn(role=Role.USER, author="Alice", text="hi"),
+        )
+    )
+    assert _texts(msgs) == [("request", "Alice: hi")]
+
+
+def test_to_model_messages_lone_assistant_history_is_empty() -> None:
+    # A reply to an image-only bot card with no prior user turn: nothing to prepend.
+    msgs = to_model_messages((Turn(role=Role.ASSISTANT, author="PetBot", text="hi"),))
+    assert msgs == []
+
+
+def test_drop_leading_assistant_keeps_from_first_user() -> None:
+    # The shared guard the mapper and post-compaction path both apply: a compacted slice
+    # that begins with a bot message is trimmed to the first user message.
+    messages: list[ModelMessage] = [
+        ModelResponse(parts=[TextPart(content="earlier bot reply")]),
+        ModelRequest(parts=[UserPromptPart(content="user")]),
+        ModelResponse(parts=[TextPart(content="bot")]),
+    ]
+    assert drop_leading_assistant(messages) == messages[1:]
+    assert drop_leading_assistant(messages[2:]) == []  # all-assistant -> nothing
 
 
 # --- reactive context compaction ----------------------------------------------

--- a/tests/process/test_process.py
+++ b/tests/process/test_process.py
@@ -7,6 +7,15 @@ from typing import Any
 
 import pytest
 from pydantic import BaseModel, ValidationError
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from petbot.domain import (
@@ -14,22 +23,33 @@ from petbot.domain import (
     EmbedSpec,
     Platform,
     Process,
+    Role,
     Skill,
     SkillContext,
     SkillResult,
     StylePort,
     TextInput,
+    Turn,
     UpstreamUnavailable,
     User,
 )
 from petbot.platform import ToolRegistry
 from petbot.process import ChatProcess, CommandProcess, PassthroughStyle, RouterProcess, Stylist
+from petbot.process.context import (
+    SlidingWindow,
+    Summarizer,
+    build_compactor,
+    is_context_overflow,
+)
+from petbot.process.history import to_model_messages
 from petbot.process.model import build_model, build_model_from_config
 from petbot.process.settings import (
     BedrockModel,
     ChatSettings,
     OpenAICompatibleModel,
     OpenRouterModel,
+    SlidingWindowContext,
+    SummarizeContext,
 )
 from petbot.types import BooruArgs, MathArgs
 
@@ -239,3 +259,138 @@ async def test_router_without_chat_rejects_conversational_input() -> None:
     router = RouterProcess(chat=None, command=_Recorder("command"))
     with pytest.raises(TypeError):
         await router.respond(TextInput(text="hi"), _ctx())
+
+
+# --- history mapping (neutral Turn -> pydantic-ai message_history) -------------
+
+
+def _texts(messages: list[ModelMessage]) -> list[tuple[str, str]]:
+    """``(kind, text)`` for each string part, for compact assertions."""
+    out: list[tuple[str, str]] = []
+    for message in messages:
+        for part in message.parts:
+            content = getattr(part, "content", None)
+            if isinstance(content, str):
+                out.append((message.kind, content))
+    return out
+
+
+def test_to_model_messages_inlines_user_author_not_assistant() -> None:
+    # The user turn is prefixed with its author (multi-user attribution); the bot turn
+    # isn't — the model owns its own replies.
+    msgs = to_model_messages(
+        (
+            Turn(role=Role.USER, author="Alice", text="show me a pony"),
+            Turn(role=Role.ASSISTANT, author="PetBot", text="here you go!"),
+        )
+    )
+    assert _texts(msgs) == [("request", "Alice: show me a pony"), ("response", "here you go!")]
+
+
+def test_to_model_messages_merges_consecutive_same_role() -> None:
+    msgs = to_model_messages(
+        (
+            Turn(role=Role.USER, author="Alice", text="one"),
+            Turn(role=Role.USER, author="Bob", text="two"),
+        )
+    )
+    assert _texts(msgs) == [("request", "Alice: one\nBob: two")]
+
+
+def test_to_model_messages_drops_empty_turns() -> None:
+    msgs = to_model_messages(
+        (
+            Turn(role=Role.USER, author="Alice", text="   "),
+            Turn(role=Role.ASSISTANT, author="PetBot", text="hi"),
+        )
+    )
+    assert _texts(msgs) == [("response", "hi")]
+
+
+# --- reactive context compaction ----------------------------------------------
+
+
+def _overflow() -> ModelHTTPError:
+    return ModelHTTPError(
+        status_code=400,
+        model_name="m",
+        body={"error": {"message": "maximum context length is 8192 tokens"}},
+    )
+
+
+def test_is_context_overflow_matches_only_length_rejections() -> None:
+    server_error = ModelHTTPError(status_code=500, model_name="m", body="boom")
+    assert is_context_overflow(_overflow()) is True
+    assert is_context_overflow(server_error) is False
+    assert is_context_overflow(ValueError("nope")) is False
+
+
+def test_build_compactor_selects_strategy_from_config() -> None:
+    assert isinstance(build_compactor(_settings(context=SlidingWindowContext())), SlidingWindow)
+    assert isinstance(build_compactor(_settings(context=SummarizeContext())), Summarizer)
+
+
+def _history(n: int) -> list[ModelMessage]:
+    return [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(n)]
+
+
+async def test_sliding_window_drops_oldest_half() -> None:
+    history = _history(4)
+    assert await SlidingWindow().compact(history) == history[2:]
+
+
+async def test_sliding_window_leaves_a_single_message() -> None:
+    history = _history(1)
+    assert await SlidingWindow().compact(history) == history
+
+
+async def test_summarizer_replaces_oldest_half_with_a_summary() -> None:
+    summarizer = Summarizer(model=TestModel(custom_output_text="earlier: ponies"))
+    history = _history(4)
+    compacted = await summarizer.compact(history)
+    assert len(compacted) == 3  # one summary note + the recent half (2)
+    assert compacted[1:] == history[2:]
+    note = compacted[0]
+    assert isinstance(note, ModelRequest)
+    assert "earlier: ponies" in _texts([note])[0][1]
+
+
+# --- the chat process retries on a provider length rejection ------------------
+
+
+async def test_chat_compacts_and_retries_on_context_overflow() -> None:
+    calls = {"n": 0}
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _overflow()
+        return ModelResponse(parts=[TextPart(content="recovered")])
+
+    chat = ChatProcess(_registry(), model=FunctionModel(fn))
+    history = tuple(
+        Turn(role=Role.USER if i % 2 == 0 else Role.ASSISTANT, author="x", text=f"t{i}")
+        for i in range(6)
+    )
+    result = await chat.respond(TextInput(text="now", history=history), _ctx())
+    assert calls["n"] == 2  # first attempt overflowed; the compacted retry succeeded
+    assert result.text == "recovered"
+
+
+async def test_chat_passes_prior_turns_as_message_history() -> None:
+    captured: list[ModelMessage] = []
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured.extend(messages)
+        return ModelResponse(parts=[TextPart(content="ok")])
+
+    chat = ChatProcess(_registry(), model=FunctionModel(fn))
+    history = (
+        Turn(role=Role.USER, author="Alice", text="what's a pony?"),
+        Turn(role=Role.ASSISTANT, author="PetBot", text="a small horse"),
+    )
+    await chat.respond(TextInput(text="and a foal?", history=history), _ctx())
+    seen = [text for _, text in _texts(captured)]
+    assert "Alice: what's a pony?" in seen
+    assert "a small horse" in seen
+    assert any("and a foal?" in text for text in seen)


### PR DESCRIPTION
## What

Makes PetBot multi-turn: **reply to a PetBot message and it continues the conversation** — no re-@mention needed. Previously chat was stateless single-shot (an `@mention` ran the agent with no `message_history`).

Built on the post-#66 process pipeline (this branch was rebased onto current `master`; the earlier pre-refactor commit was dropped).

## How

**Memory — reply-to-continue, reconstructed frontend-side (Route A).**
- `frontends/discord/history.py` walks the `message.reference` chain (bounded by `HISTORY_MAX_TURNS`, default 25) into neutral `Turn` values.
- History rides on **`TextInput.history`** — the conversational variant of the `Input` sum type, so a `CommandInput` can't carry chat history; not on the shared `SkillContext`, and not a compute-side store (which can't see Discord's reply chain). The compute service stays a stateless, pure function of `(Input, SkillContext)`.
- `Role` is neutral `USER`/`ASSISTANT`; the name "PetBot" lives in `Turn.author` (from the live Discord display name). A user turn inlines its author for multi-user attribution; an **image-only bot card is flattened to a faithful text description** (title + image URL), since an assistant turn is text-only in the model's history.
- PetBot answers as a Discord reply (`mention_author=False`) so each reply is an anchor.

**Context window — reactive, no magic number.**
- pydantic-ai doesn't expose a model's context-window size (upstream [#4538](https://redirect.github.com/pydantic/pydantic-ai/issues/4538)) and has no turnkey compaction ([#4137](https://redirect.github.com/pydantic/pydantic-ai/issues/4137)), so a configured token budget would be wrong on a model swap.
- Instead the **provider is the trigger**: the chat process attempts the run, and only if it's rejected for length does it compact and retry (bounded). Strategy is **DI-selectable** via `CHAT_CONTEXT__KIND` (a config `match`, like `build_model_from_config`): a zero-cost **sliding window** or an **LLM summarizer** (stylizer tier). `to_model_messages` stays a pure mapper.

## DDD/DI notes
- Memory enters the pipeline at one principled point (`TextInput.history`); the core stays pure.
- The compaction strategy mirrors the existing `StylePort`/`Stylist` + `build_model_from_config` patterns; it's process-level (operates on pydantic-ai `ModelMessage`), not a domain port. The only added conditionals are exhaustive `match`es on closed types + one error boundary.

## Tests & gates
`102 passed`; `ruff` / `ruff format` / `mypy --strict` / `lint-imports` all green. New/updated tests cover the mapper, both compaction strategies, overflow detection + the chat retry path, reply-chain reconstruction (incl. image-card flattening and graceful stops), reply threading, and the `Input` round-trip.

See [`docs/adr/0010-conversational-memory-reply-to-continue.md`](docs/adr/0010-conversational-memory-reply-to-continue.md).

## Out of scope
Compute-side `SessionStore`; reply-about-another-message as explicit quoting; proactive precise token budgeting (deferred until the upstream window-size gap is fixed); the `Notifier`/streaming path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2b3SvKc1qptAC4G7NTTv