### PR TITLE
deploy: expose HISTORY_MAX_TURNS + CHAT_CONTEXT__KIND as Terraform vars

### DIFF
--- a/deploy/terraform/edge.tf
+++ b/deploy/terraform/edge.tf
@@ -78,6 +78,9 @@ resource "aws_lightsail_container_service_deployment_version" "edge" {
       SERVICE__KIND          = "lambda"
       SERVICE__FUNCTION_NAME = aws_lambda_function.this.function_name
       AWS_REGION             = var.aws_region
+      # Reply-chain fetch depth for conversation-history reconstruction (a Discord-API
+      # cost bound, not a model-context bound).
+      HISTORY_MAX_TURNS = tostring(var.history_max_turns)
       # Scoped identity for boto3's default credential chain (Lightsail container
       # services have no IAM instance roles, so a static key is the mechanism).
       AWS_ACCESS_KEY_ID     = aws_iam_access_key.edge.id

--- a/deploy/terraform/secrets.tf
+++ b/deploy/terraform/secrets.tf
@@ -45,6 +45,9 @@ locals {
       # ChatSettings reads (CHAT_LLM__KIND / CHAT_LLM__MODEL[ / __BASE_URL / __API_KEY]).
       CHAT_LLM__KIND  = var.chat_llm_kind
       CHAT_LLM__MODEL = var.chat_llm_model
+      # How an over-long conversation is compacted when the model rejects it for
+      # length (reactive). Default sliding_window; summarize uses the stylizer tier.
+      CHAT_CONTEXT__KIND = var.context_kind
     },
     var.chat_llm_base_url != "" ? { CHAT_LLM__BASE_URL = var.chat_llm_base_url } : {},
     var.user_agent != "" ? { USER_AGENT = var.user_agent } : {},

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -104,6 +104,23 @@ variable "chat_llm_api_key_ssm_parameter" {
   default     = ""
 }
 
+variable "context_kind" {
+  type        = string
+  description = <<-EOT
+    How the chat agent compacts an over-long conversation *when the model rejects it
+    for length* (reactive — there is no token budget to set):
+      sliding_window - drop the oldest half (zero cost; default).
+      summarize      - summarise the oldest half with the stylizer-tier model.
+    Sets CHAT_CONTEXT__KIND in the worker.
+  EOT
+  default     = "sliding_window"
+
+  validation {
+    condition     = contains(["sliding_window", "summarize"], var.context_kind)
+    error_message = "context_kind must be one of: sliding_window, summarize."
+  }
+}
+
 variable "booru_ssm_parameters" {
   type        = map(string)
   description = <<-EOT
@@ -174,4 +191,14 @@ variable "edge_image_tag" {
     with no deployment (apply the service first, then push + set this).
   EOT
   default     = ""
+}
+
+variable "history_max_turns" {
+  type        = number
+  description = <<-EOT
+    How many reply-chain ancestors the edge fetches when reconstructing conversation
+    history (a Discord-API cost bound, not a model-context bound). Sets
+    HISTORY_MAX_TURNS in the edge container.
+  EOT
+  default     = 25
 }


### PR DESCRIPTION
## What

Makes the conversational-memory knobs from #64 **explicit and overridable** in the deployed environment, as plain Terraform variables with defaults.

- `variables.tf` — `history_max_turns` (number, default `25`) + `context_kind` (string, default `"sliding_window"`, validated `sliding_window|summarize`)
- `secrets.tf` — `CHAT_CONTEXT__KIND = var.context_kind` on the core Lambda env (`base_env`)
- `edge.tf` — `HISTORY_MAX_TURNS = tostring(var.history_max_turns)` on the edge container env

## Why not GitHub Variables

The `vars.CHAT_LLM_*` are on GitHub because they're per-deployment *choices* (provider/model/key) that can't live in code. These two are stable app-tuning knobs with sane defaults, so Terraform-var defaults are the right home — explicit in code, overridable via `terraform.tfvars`, and no empty-`vars` → empty-`TF_VAR` footgun.

## Behaviour

**No change** — the defaults equal the app's own code defaults (`25` / `sliding_window`). This just surfaces them in the deployed config and makes them tunable, e.g. `context_kind = "summarize"` in `terraform.tfvars`.

## Notes

- Terraform isn't installed in the dev container; CI (`terraform.yml`) will `fmt`/`validate`. The additions are comment-isolated so `=` alignment stays `fmt`-clean.
- Draft pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CV2b3SvKc1qptAC4G7NTTv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV2b3SvKc1qptAC4G7NTTv)_