### PR TITLE
fix(booru): verify the cause of an empty search before blaming the safe floor

### DIFF
--- a/src/petbot/domain/errors.py
+++ b/src/petbot/domain/errors.py
@@ -29,7 +29,16 @@ class InvalidInput(SkillError):
 
 
 class EmptyResult(SkillError):
-    """A search or lookup that ran cleanly but found nothing."""
+    """A search or lookup that ran cleanly but found nothing.
+
+    ``reason`` is an optional machine-readable tag (a plain string so the domain stays
+    provider-agnostic) letting the skill layer classify *why* it was empty for telemetry,
+    without re-deriving it. ``None`` when the caller has no finer signal than the message.
+    """
+
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 class UpstreamUnavailable(SkillError):

--- a/src/petbot/skills/booru/engine.py
+++ b/src/petbot/skills/booru/engine.py
@@ -10,6 +10,7 @@ body still raises rather than silently looking like "no results".
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 
 import httpx
 
@@ -17,7 +18,7 @@ from petbot.domain import SkillResult
 from petbot.skills.booru.base import BooruProvider
 from petbot.skills.booru.errors import SiteFailureStatusError
 from petbot.skills.booru.render import render
-from petbot.skills.booru.types import SearchRequest
+from petbot.skills.booru.types import EmptyReason, SearchRequest
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,40 @@ async def run_search(
             print_message=_site_unreadable(provider.name),
         )
 
-    return render(provider.parse(body), request=search)
+    post = provider.parse(body)
+    if post is not None:
+        return render(post, request=search)
+    empty_reason = await _classify_empty(provider, client, search)
+    return render(None, request=search, empty_reason=empty_reason)
+
+
+async def _classify_empty(
+    provider: BooruProvider,
+    client: httpx.AsyncClient,
+    search: SearchRequest,
+) -> EmptyReason:
+    """Decide *why* a search came back empty, so the bot states a cause it can stand behind.
+
+    A non-safe search already looked at everything: it's a plain ``NO_MATCH``. For a
+    safe-only search the emptiness might be the safe floor *or* genuinely no posts — and
+    the renderer must not guess. So we probe: re-run the same search rating-agnostic and
+    see if anything exists. The probe's result is **discarded** (a SFW channel never shows
+    an explicit post); we only learn whether matches exist beyond the floor. Only then is
+    ``SAFE_FLOOR`` ("try an NSFW channel") true. If the probe finds nothing — or can't run
+    — we fall back to ``NO_MATCH`` rather than claim a cause we didn't verify.
+    """
+    if not search.safe_only:
+        return EmptyReason.NO_MATCH
+    probe = replace(search, safe_only=False)
+    try:
+        response = await client.send(provider.build_request(client, probe))
+        body = _json_body(response)
+    except httpx.HTTPError:
+        logger.debug("%s empty-result probe failed; reporting no_match", provider.name)
+        return EmptyReason.NO_MATCH
+    if body is not None and provider.error(body) is None and provider.parse(body) is not None:
+        return EmptyReason.SAFE_FLOOR
+    return EmptyReason.NO_MATCH
 
 
 def _json_body(response: httpx.Response) -> object | None:

--- a/src/petbot/skills/booru/render.py
+++ b/src/petbot/skills/booru/render.py
@@ -13,38 +13,34 @@ process's stylist), never shipped from here.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import StrEnum
 
 from petbot.domain import EmbedSpec, EmptyResult, SkillResult
-from petbot.skills.booru.types import Post, SearchRequest
-
-
-class EmptyReason(StrEnum):
-    """Why a search came back empty — the fact the persona layer relays."""
-
-    #: A safe-only search (the channel isn't age-gated) found nothing.
-    SAFE_FLOOR = "safe_floor"
-    #: A search that looked at everything available found nothing.
-    NO_MATCH = "no_match"
-
+from petbot.skills.booru.types import EmptyReason, Post, SearchRequest
 
 #: One factual note per reason. Stated plainly so whoever voices it (chat agent or
-#: stylist) relays the real reason instead of inventing one (a typo, etc.).
+#: stylist) relays the real reason instead of inventing one (a typo, etc.). The
+#: ``SAFE_FLOOR`` note promises an NSFW channel has matches only because the engine has
+#: *verified* that (a rating-agnostic probe), so the bot never claims a cause it guessed.
 _EMPTY_NOTE: dict[EmptyReason, str] = {
     EmptyReason.SAFE_FLOOR: (
-        "No results. This channel isn't age-gated, so only safe-rated posts were "
-        "searched — there may be more in an NSFW channel."
+        "No safe-rated results for those tags. This channel isn't age-gated, so only "
+        "safe posts were searched — an NSFW channel has matches for these tags."
     ),
     EmptyReason.NO_MATCH: "No results found for those tags.",
 }
 
 
-def render(post: Post | None, *, request: SearchRequest) -> SkillResult:
+def render(
+    post: Post | None,
+    *,
+    request: SearchRequest,
+    empty_reason: EmptyReason = EmptyReason.NO_MATCH,
+) -> SkillResult:
     """Render a found post. An empty search **raises** :class:`EmptyResult`, whose factual
-    note the process output boundary voices in persona."""
+    note (selected by the engine-verified ``empty_reason``) the process output boundary
+    voices in persona."""
     if post is None:
-        reason = EmptyReason.SAFE_FLOOR if request.safe_only else EmptyReason.NO_MATCH
-        raise EmptyResult(_EMPTY_NOTE[reason])
+        raise EmptyResult(_EMPTY_NOTE[empty_reason], reason=empty_reason.value)
 
     if post.total is not None:
         title = f"{post.total} result{'s' if post.total != 1 else ''}: {tags_label(request.tags)}"

--- a/src/petbot/skills/booru/skill.py
+++ b/src/petbot/skills/booru/skill.py
@@ -19,7 +19,7 @@ from petbot.skills.booru.base import BooruProvider
 from petbot.skills.booru.engine import run_search
 from petbot.skills.booru.errors import SiteFailureStatusError
 from petbot.skills.booru.tags import NumericFilter, Sort
-from petbot.skills.booru.types import BooruOutcome, SearchRequest
+from petbot.skills.booru.types import BooruOutcome, EmptyReason, SearchRequest
 from petbot.types import BooruArgs
 
 logger = logging.getLogger(__name__)
@@ -77,8 +77,11 @@ async def _run(
     # propagates untouched — we only tag it on the way past.
     try:
         result = await run_search(provider, client, search)
-    except EmptyResult:
-        empty = BooruOutcome.SAFE_LIMITED if search.safe_only else BooruOutcome.EMPTY
+    except EmptyResult as exc:
+        # SAFE_LIMITED only when the engine *verified* the safe floor is the cause
+        # (its probe found matches beyond it); a bare safe_only flag is not enough.
+        safe_limited = exc.reason == EmptyReason.SAFE_FLOOR
+        empty = BooruOutcome.SAFE_LIMITED if safe_limited else BooruOutcome.EMPTY
         _record_outcome(provider.name, empty)
         raise
     except SiteFailureStatusError as exc:

--- a/src/petbot/skills/booru/types.py
+++ b/src/petbot/skills/booru/types.py
@@ -15,6 +15,19 @@ from enum import StrEnum
 from petbot.skills.booru.tags import FileType, NumericFilter, Rating, Sort
 
 
+class EmptyReason(StrEnum):
+    """Why a search came back empty — a *verified* fact, not a guess from the request.
+
+    ``SAFE_FLOOR`` is claimed only when a probe (a rating-agnostic re-run whose results
+    are discarded, never shown) confirms matches exist beyond the safe floor, so "try an
+    NSFW channel" is true. ``NO_MATCH`` covers a non-safe search, a safe search whose
+    probe also found nothing, and the case where the probe couldn't run — i.e. whenever we
+    cannot honestly pin the emptiness on the safe floor."""
+
+    SAFE_FLOOR = "safe_floor"
+    NO_MATCH = "no_match"
+
+
 class BooruOutcome(StrEnum):
     """The coarse, non-content result of a search, recorded as telemetry. The skill
     classifies each search into one of these: it can't be read off a single exception type,

--- a/tests/skills/booru/test_booru.py
+++ b/tests/skills/booru/test_booru.py
@@ -6,6 +6,8 @@ by inspecting the ``httpx.Request`` that a provider builds (no network needed).
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import httpx
 import pytest
 import respx
@@ -256,18 +258,50 @@ async def test_e621_skill_empty_raises_empty_result() -> None:
             await skill.run(BooruArgs(tags="asdfqwer"), make_context())
 
 
+def _safe_floor_mock(*, unfiltered_has_results: bool) -> Callable[[httpx.Request], httpx.Response]:
+    """A respx side-effect that models the safe floor honestly: the safe-only request
+    (``rating:s`` in its tags) is empty, while the engine's rating-agnostic probe returns
+    a hit iff ``unfiltered_has_results``. Distinguishing the two requests is the whole
+    point — it's what lets the skill tell a floor-suppressed search from a true blank."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        tags_param = request.url.params.get("tags", "")
+        is_safe_request = "rating:s" in tags_param
+        if not is_safe_request and unfiltered_has_results:
+            return httpx.Response(200, json=load_fixture("e621_success"))
+        return httpx.Response(200, json=load_fixture("e621_empty"))
+
+    return handler
+
+
 @respx.mock
-async def test_e621_skill_empty_sfw_explains_rating_floor() -> None:
-    # An empty search in a SFW channel must state *why* (the safe-rating floor), so the
-    # voice layer relays the real reason instead of inventing one (a typo, etc.).
+async def test_e621_skill_empty_sfw_blames_floor_only_when_probe_confirms() -> None:
+    # SFW channel, safe search empty, but the same tags DO have (non-safe) matches: the
+    # engine's probe confirms the safe floor is the real cause, so the note may point the
+    # user at an NSFW channel. This is the only case where that advice is true.
     respx.get("https://e621.net/posts.json").mock(
-        return_value=httpx.Response(200, json=load_fixture("e621_empty"))
+        side_effect=_safe_floor_mock(unfiltered_has_results=True)
     )
     async with httpx.AsyncClient() as client:
         skill = E621Skill(client=client, user_agent="PetBot/2.1 (test)")
         with pytest.raises(EmptyResult) as exc:
             await skill.run(BooruArgs(tags="auzbuzzard"), make_context(allows_explicit=False))
     assert "age-gated" in exc.value.message
+
+
+@respx.mock
+async def test_e621_skill_empty_sfw_no_floor_blame_when_truly_empty() -> None:
+    # SFW channel, and the tags have NO matches at any rating (the probe also comes back
+    # empty). The bot must NOT blame the safe floor or suggest an NSFW channel — that would
+    # be a lie. It reports a plain no-result instead.
+    respx.get("https://e621.net/posts.json").mock(
+        side_effect=_safe_floor_mock(unfiltered_has_results=False)
+    )
+    async with httpx.AsyncClient() as client:
+        skill = E621Skill(client=client, user_agent="PetBot/2.1 (test)")
+        with pytest.raises(EmptyResult) as exc:
+            await skill.run(BooruArgs(tags="auzbuzzard"), make_context(allows_explicit=False))
+    assert "age-gated" not in exc.value.message
 
 
 @respx.mock

--- a/tests/skills/booru/test_outcome.py
+++ b/tests/skills/booru/test_outcome.py
@@ -50,6 +50,27 @@ async def test_outcome_ok() -> None:
 
 @respx.mock
 async def test_outcome_safe_limited_when_safe_floor_empties_it() -> None:
+    # safe_limited is recorded only when the floor *verifiably* caused the emptiness: the
+    # safe request (rating:s) is empty while the engine's rating-agnostic probe finds a hit.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "rating:s" in request.url.params.get("tags", ""):
+            return httpx.Response(200, json=load_fixture("e621_empty"))
+        return httpx.Response(200, json=load_fixture("e621_success"))
+
+    respx.get("https://e621.net/posts.json").mock(side_effect=handler)
+    async with httpx.AsyncClient() as client:
+        outcome = await _outcome_of(
+            lambda: _skill(client).run(
+                BooruArgs(tags="canine"), make_context(allows_explicit=False)
+            )
+        )
+    assert outcome == "safe_limited"
+
+
+@respx.mock
+async def test_outcome_empty_when_safe_search_is_truly_empty() -> None:
+    # SFW channel but the tags have no matches at any rating (probe also empty): this is a
+    # plain EMPTY, not safe_limited — the floor is not to blame.
     respx.get("https://e621.net/posts.json").mock(
         return_value=httpx.Response(200, json=load_fixture("e621_empty"))
     )
@@ -59,7 +80,7 @@ async def test_outcome_safe_limited_when_safe_floor_empties_it() -> None:
                 BooruArgs(tags="canine"), make_context(allows_explicit=False)
             )
         )
-    assert outcome == "safe_limited"
+    assert outcome == "empty"
 
 
 @respx.mock


### PR DESCRIPTION
## Why

From the `dev-chat` screenshot: PetBot "couldn't find" an e621 image and told the user to "try a safe search" / "try an NSFW channel" — both misleading.

## Bug

`render.py` derived the empty-result reason from the `safe_only` flag alone: any empty safe-only search was reported as *"this channel isn't age-gated — there may be more in an NSFW channel,"* and tagged `SAFE_LIMITED` in telemetry. That's a **guess**, never verified.

Verified live against e621 for the screenshot's tags:

| query | posts |
|---|---|
| `striped_hyena rating:s` | has results |
| `detailed_background concept_art striped_hyena rating:s` | **0** |
| `detailed_background concept_art striped_hyena` *(no safe floor)* | **0** |

The combo is empty **regardless of rating** — so "try an NSFW channel" was false, and `SAFE_LIMITED` was the wrong status. (Also `digital_art` isn't the canonical e621 tag — `digital_media_(artwork)` is.)

## Fix

On an empty safe-only search the engine now **probes**: re-runs rating-agnostic, **discards** the result (nothing explicit is ever surfaced in a SFW channel), and only claims `SAFE_FLOOR` ("try NSFW") when matches actually exist beyond the floor. Otherwise — or if the probe can't run — it reports a plain `NO_MATCH`. `EmptyResult` carries the verified reason so the skill classifies `SAFE_LIMITED` vs `EMPTY` from fact, not the request flag. `EmptyReason` moves to `booru/types.py`.

Tests updated to model the floor honestly (probe-aware respx mock). **131 pass** (was 129); ruff + mypy clean.

> Observability (the collector + CI enablement that would have *logged* this incident) is split into a separate branch/PR — `claude/petbot-observability-collector` — since it needs a real `docker build` / `terraform apply` the web environment can't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)