### PR TITLE
fix(chat): pin Gemma schema profile so mantle tool calls don't leak

### DIFF
--- a/docs/adr/0006-gateway-edge-microservice-skills.md
+++ b/docs/adr/0006-gateway-edge-microservice-skills.md
@@ -98,6 +98,17 @@ is consolidated** until scale justifies splitting:
   variants: `bedrock` (Converse + IAM: Nova/Claude), `openai_compatible` (base URL
   + key: Gemma 4 mantle today, a self-hosted Ollama/vLLM later), and `openrouter`.
   Gemma 4 prod uses `openai_compatible`.
+- Correction (2026-06): "the model is the same across both, so the provider is a
+  config flip" is **not free** — it was a leaky abstraction. pydantic-ai derives a
+  model's *profile* (which shapes the tool JSON-schema sent to the model) from the
+  **provider**, not the model: `OpenRouterProvider` recognises the `google/` prefix
+  and sends Gemma the Gemini schema subset, but the generic `OpenAIProvider` (how we
+  reach mantle) cannot know the model behind a custom base URL is Gemma, so it sent
+  raw OpenAI schemas. Gemma then couldn't parse the tools and **narrated tool calls
+  as plain text**, which leaked to users. Fixed by pinning the profile *by model
+  identity* in `petbot.process.model` (`_openai_compatible_profile`), so dev and prod
+  drive the same model identically. The "config flip" holds only because the builder
+  now enforces it; it is not automatic.
 
 ### 5. Repository structure — uv workspace, hexagonal
 

--- a/docs/adr/0007-llm-agent-pydantic-ai.md
+++ b/docs/adr/0007-llm-agent-pydantic-ai.md
@@ -21,9 +21,12 @@ Implement chat as a normal skill — `petbot.skills.chat` — built on **pydanti
   declaration feeds the typed client, the worker's validation, and the LLM tool
   schema. Tool bodies dispatch through a `Skills` client (`SkillsClient` over a
   local transport in the core worker — an in-process hop, no wire round-trip).
-- The model is **provider-agnostic**, chosen by `CHAT_PROVIDER`: Amazon Bedrock
-  for prod (a real, cheap on-Bedrock model — note Bedrock does *not* host Gemma),
-  an OpenAI-compatible endpoint (OpenRouter, with free models like Gemma) for dev.
+- The model is **provider-agnostic**, chosen by `CHAT_LLM__KIND`. (Correction,
+  2026-06: an earlier draft of this line said "Bedrock does *not* host Gemma" and
+  framed Gemma as dev-only. That is **wrong** — see [ADR 0006](0006-gateway-edge-microservice-skills.md) §4:
+  **Gemma 4 is the prod default**, served on Bedrock via the OpenAI-compatible
+  `bedrock-mantle` endpoint (`openai_compatible`), with OpenRouter's free Gemma as
+  the dev scaffold and Bedrock Converse — `bedrock` — available for Nova/Claude.)
   Model ids are configuration, never code.
 - The chat skill folds the model's prose plus any rich card a tool produced (a
   booru image) into a single neutral `SkillResult`, so the edge renders it

--- a/src/petbot/process/model.py
+++ b/src/petbot/process/model.py
@@ -8,9 +8,13 @@ stylizer (:meth:`ChatSettings.stylizer_llm`), since both are the same ``LLMConfi
 
 from __future__ import annotations
 
-from typing import assert_never
+from dataclasses import replace
+from typing import Any, assert_never
 
 from pydantic_ai.models import Model
+from pydantic_ai.profiles import ModelProfile
+from pydantic_ai.profiles.google import GoogleJsonSchemaTransformer
+from pydantic_ai.profiles.openai import openai_model_profile
 
 from petbot.process.settings import (
     BedrockModel,
@@ -21,6 +25,45 @@ from petbot.process.settings import (
 )
 
 
+class _GeminiToolSchema(GoogleJsonSchemaTransformer):
+    """Gemini-subset JSON-schema transformer that also inlines ``$defs`` and collapses
+    nullable unions — what Gemma needs to *see* a tool over an OpenAI-compatible endpoint.
+
+    Gemma/Gemini accept only `a subset of OpenAPI v3.0.3
+    <https://ai.google.dev/gemini-api/docs/function-calling>`_ for tool args: no ``title``,
+    no ``$ref``/``$defs``, no ``anyOf`` nullable unions. The base
+    :class:`GoogleJsonSchemaTransformer` pops the unsupported *keys*; the two constructor
+    flags additionally inline ``$defs`` and rewrite ``str | None`` (an ``anyOf`` with
+    ``null``) to ``{"nullable": true}``. Both come up in our ``*Args`` models (``BooruArgs``
+    has optional fields), so without them Gemma receives a schema it can't parse, never sees
+    the tool, and narrates a free-text call that leaks to the user instead of invoking it.
+    """
+
+    def __init__(self, schema: dict[str, Any], *, strict: bool | None = None) -> None:
+        super().__init__(
+            schema, strict=strict, prefer_inlined_defs=True, simplify_nullable_unions=True
+        )
+
+
+def _openai_compatible_profile(model_name: str) -> ModelProfile | None:
+    """The chat-model profile for a model reached over an OpenAI-compatible endpoint, chosen
+    by **model identity** rather than by which provider connects.
+
+    pydantic-ai derives the profile from the *provider*: ``OpenRouterProvider`` sniffs the
+    ``google/`` prefix and applies Gemma-aware schema handling, but a generic
+    ``OpenAIProvider`` (how we reach Gemma 4 on Bedrock's ``mantle`` endpoint) cannot know the
+    model behind a custom base URL is Gemma, so it falls back to the plain OpenAI profile and
+    sends Gemma schemas it rejects. We pin the profile here so dev (OpenRouter) and prod
+    (mantle) drive the *same* model identically — the "config flip" the architecture intends.
+
+    Returns ``None`` (defer to the provider default) for models we don't special-case.
+    """
+    name = model_name.lower()
+    if "gemma" in name or "gemini" in name:
+        return replace(openai_model_profile(model_name), json_schema_transformer=_GeminiToolSchema)
+    return None
+
+
 def build_model_from_config(llm: LLMConfig) -> Model:
     """Construct an LLM model from one discriminated provider config (either role)."""
     match llm:
@@ -28,13 +71,19 @@ def build_model_from_config(llm: LLMConfig) -> Model:
             from pydantic_ai.models.openai import OpenAIChatModel
             from pydantic_ai.providers.openrouter import OpenRouterProvider
 
-            return OpenAIChatModel(model, provider=OpenRouterProvider(api_key=api_key))
+            return OpenAIChatModel(
+                model,
+                provider=OpenRouterProvider(api_key=api_key),
+                profile=_openai_compatible_profile(model),
+            )
         case OpenAICompatibleModel(model=model, base_url=base_url, api_key=api_key):
             from pydantic_ai.models.openai import OpenAIChatModel
             from pydantic_ai.providers.openai import OpenAIProvider
 
             return OpenAIChatModel(
-                model, provider=OpenAIProvider(base_url=base_url, api_key=api_key)
+                model,
+                provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+                profile=_openai_compatible_profile(model),
             )
         case BedrockModel(model=model):
             from pydantic_ai.models.bedrock import BedrockConverseModel

--- a/tests/process/test_process.py
+++ b/tests/process/test_process.py
@@ -168,6 +168,61 @@ def test_build_model_from_config_builds_each_role() -> None:
     assert isinstance(build_model_from_config(cfg), OpenAIChatModel)
 
 
+# --- Gemma schema parity: dev (OpenRouter) and prod (mantle) drive Gemma identically -------
+# Gemma emits tool calls in its own format and only accepts the Gemini subset of JSON Schema.
+# pydantic-ai picks the schema handling from the *provider*, so the same Gemma model would get
+# Gemma-aware schemas on OpenRouter but raw OpenAI schemas on a generic endpoint (Bedrock
+# mantle) — Gemma then can't see the tools and narrates a free-text call that leaks to the user.
+# We pin the profile by model identity so both paths send Gemma the same, parseable schemas.
+
+
+def test_gemma_pins_gemini_schema_transformer_on_mantle() -> None:
+    from petbot.process.model import _GeminiToolSchema
+
+    cfg = OpenAICompatibleModel(
+        model="google.gemma-4-26b-a4b",
+        base_url="https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+        api_key="k",
+    )
+    model = build_model_from_config(cfg)
+    assert model.profile is not None
+    assert model.profile.json_schema_transformer is _GeminiToolSchema
+
+
+def test_gemma_schema_handling_is_identical_dev_and_prod() -> None:
+    # OpenRouter (dev scaffold) and mantle (prod) must end up with the *same* transformer for
+    # the same model — no silent per-provider divergence.
+    dev = build_model_from_config(OpenRouterModel(model="google/gemma-3-27b-it:free", api_key="k"))
+    prod = build_model_from_config(
+        OpenAICompatibleModel(model="google.gemma-4-26b-a4b", base_url="https://x/v1", api_key="k")
+    )
+    assert dev.profile.json_schema_transformer is prod.profile.json_schema_transformer
+
+
+def test_non_gemma_openai_compatible_keeps_provider_default() -> None:
+    # A non-Gemma OpenAI-compatible endpoint (e.g. a self-hosted GPT-ish model) must not get
+    # the Gemini transformer forced on it.
+    from petbot.process.model import _GeminiToolSchema
+
+    model = build_model_from_config(
+        OpenAICompatibleModel(model="some-llama-3", base_url="https://x/v1", api_key="k")
+    )
+    assert model.profile.json_schema_transformer is not _GeminiToolSchema
+
+
+def test_gemini_tool_schema_makes_args_gemma_parseable() -> None:
+    # The transformer must actually fix a real *Args schema: drop `title`, inline `$defs`, and
+    # collapse `str | None` (an anyOf-with-null) to a plain nullable field Gemma accepts.
+    from petbot.process.model import _GeminiToolSchema
+
+    raw = BooruArgs.model_json_schema()
+    transformed = _GeminiToolSchema(raw).walk()
+    sort = transformed["properties"]["sort"]
+    assert "anyOf" not in sort and sort.get("nullable") is True
+    assert "title" not in sort
+    assert "$defs" not in transformed and "$ref" not in str(transformed)
+
+
 # --- the stylist (the persona voice) ------------------------------------------
 
 


### PR DESCRIPTION
## Symptom
PetBot replied with its prose **and the literal tool call as text** — `e621(tags="yeen sexy", sort="score", descending=true)` — no image, no search run.

## Root cause (researched, not patched over)
Three facts compose into the leak:

1. **Gemma 4 doesn't emit OpenAI-style `tool_calls`.** It emits calls in its own token format (`<|tool_call>call:name{…}<tool_call|>`) and accepts only the **Gemini subset** of JSON Schema for tool args — no `title`, `$defs`/`$ref`, or `anyOf` nullable unions. ([Google docs](https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4))
2. **pydantic-ai builds a tool call only from the structured `tool_calls` field** (`models/openai.py`). Anything in `message.content` becomes plain text — no text fallback parser. Known cross-ecosystem Gemma 4 bug ([llama.cpp #22786](https://github.com/ggml-org/llama.cpp/issues/22786), [llama-cpp-python #2227](https://github.com/abetlen/llama-cpp-python/issues/2227), [mlx-lm #1096](https://github.com/ml-explore/mlx-lm/issues/1096)).
3. **pydantic-ai picks a model's profile (which shapes the tool schema sent) from the _provider_, not the model.** `OpenRouterProvider` (dev) sniffs the `google/` prefix and sends Gemma-correct schemas; the generic `OpenAIProvider` we use for Bedrock's `bedrock-mantle` endpoint (prod) can't know the model behind a custom base URL is Gemma, so it sent **raw OpenAI schemas**. Gemma couldn't see the tools, improvised a free-text call, and pydantic-ai surfaced it as prose.

So dev (OpenRouter) and prod (mantle) were **never equivalent** despite ADR 0006's "same model, provider is a config flip" — a leaky abstraction nobody authored deliberately; it lives inside pydantic-ai's provider defaults.

## Fix
Choose the profile by **model identity** (`_openai_compatible_profile` in `model.py`) and pin a Gemini-subset schema transformer (`_GeminiToolSchema` — pops unsupported keys, inlines `$defs`, collapses nullable unions) for Gemma/Gemini on **both** the OpenRouter and OpenAI-compatible paths. Provider objects unchanged (mantle still via `OpenAIProvider` — the AWS-documented way); only the schema handling is corrected and forced identical across dev/prod.

## Docs
- ADR 0006: the "config flip" claim corrected — it holds only because the builder now enforces it.
- ADR 0007: corrected the stale "Bedrock does not host Gemma / Gemma is dev-only" line — Gemma 4 is the **prod default**, served on Bedrock via mantle.

## Tests
Profile pinning on mantle, dev/prod transformer parity, non-Gemma keeps the provider default, and a real `BooruArgs` schema becomes Gemma-parseable (no `title`/`anyOf`/`$defs`, `str | None` → `nullable`).

All 133 tests pass; ruff, ruff format, mypy --strict, lint-imports (6/6) clean.

## ⚠️ One thing I can't verify from CI
I can't reach mantle (no Bedrock creds / network here), so I can't *prove* the schema was the live trigger vs. a mantle-side parse gap. The profile fix is correct and necessary regardless; **confirming it fully clears the leak needs one real prod call.** (Replaces the earlier band-aid that only hid the symptom.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)