### PR TITLE
fix(discord): respond in DMs; stop prod chat crash from unpinned pydantic-ai

### DIFF
--- a/deploy/Dockerfile.lambda
+++ b/deploy/Dockerfile.lambda
@@ -24,14 +24,19 @@ COPY --from=ghcr.io/astral-sh/uv:0.8.17 /uv /bin/uv
 # ${LAMBDA_TASK_ROOT} is /var/task, already the WORKDIR and on sys.path. PetBot is
 # one package; install only the core-worker extra so the image carries the chat +
 # booru + math deps and not discord.py.
-COPY pyproject.toml README.md ./
+COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 
-# `.[compute-core]` is the core compute dependency set; no frontend/music deps land.
+# Install the *locked* dependency set, so a rebuild resolves exactly what CI tested
+# rather than re-floating every `>=` to its latest (which once pulled pydantic-ai 2.x
+# and broke the chat model build in prod while CI stayed green). `uv export` emits the
+# lock's pins for the compute-core extra; the project itself is then installed --no-deps.
 # The cache mount persists wheel downloads between builds. No secrets are baked
 # in — Terraform supplies booru creds + the chat model config as env vars.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --compile-bytecode ".[compute-core]"
+    uv export --frozen --no-emit-project --extra compute-core -o /tmp/requirements.txt \
+    && uv pip install --system --compile-bytecode -r /tmp/requirements.txt \
+    && uv pip install --system --compile-bytecode --no-deps .
 
 # module.function the Lambda runtime invokes per request.
 CMD ["petbot.services.core.handler.handler"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ compute-core = [
     "pydantic-settings>=2.14",
     "numexpr>=2.14",
     "numpy>=2.4",
-    "pydantic-ai-slim[bedrock,openai]>=1.107",
+    # Capped below the next major: 2.x changed `openai_model_profile` to return a
+    # non-dataclass, breaking the `dataclasses.replace` in process/model.py. A rebuilt
+    # image must not pull a new major out from under the pinned lock.
+    "pydantic-ai-slim[bedrock,openai]>=1.107,<2",
 ]
 # The music compute service: its own gateway plus voice playback.
 compute-music = [

--- a/src/petbot/frontends/discord/bot.py
+++ b/src/petbot/frontends/discord/bot.py
@@ -20,7 +20,11 @@ from discord.ext import commands
 
 from petbot.domain import History, Process, Recalled, SkillResult, TextInput, Unrecalled
 from petbot.frontends.discord.context import build_context
-from petbot.frontends.discord.history import reconstruct, replying_to_self, strip_self_mention
+from petbot.frontends.discord.history import (
+    is_conversational_trigger,
+    reconstruct,
+    strip_self_mention,
+)
 from petbot.frontends.discord.render import SERVICE_UNREACHABLE, respond
 from petbot.frontends.discord.settings import DiscordSettings, HttpService, LambdaService
 from petbot.frontends.discord.slash import build_commands
@@ -81,12 +85,12 @@ class PetBot(commands.Bot):
             logger.info("Logged in as %s (discord.py %s).", self.user, discord.__version__)
 
     async def on_message(self, message: discord.Message) -> None:
-        # Conversational entry: an @mention, OR a reply to one of PetBot's own messages
-        # (so a follow-up needs no re-mention). Other bots and our own messages are ignored.
+        # Conversational entry — see `is_conversational_trigger`: a DM (always), or a guild
+        # @mention / reply-to-self. Other bots and our own messages are ignored.
         if message.author.bot or self.user is None:
             return
         bot_user_id = self.user.id
-        if self.user not in message.mentions and not replying_to_self(message, bot_user_id):
+        if not is_conversational_trigger(message, bot_user_id):
             return
         text = strip_self_mention(message.content, bot_user_id).strip()
         if not text:

--- a/src/petbot/frontends/discord/history.py
+++ b/src/petbot/frontends/discord/history.py
@@ -113,6 +113,18 @@ def replying_to_self(message: discord.Message, bot_user_id: int) -> bool:
     return resolved.author.id == bot_user_id
 
 
+def is_conversational_trigger(message: discord.Message, bot_user_id: int) -> bool:
+    """Whether ``message`` should start or continue a conversation with PetBot.
+
+    A DM is always addressed to the bot, so every DM triggers with no @mention. In a guild
+    it takes an explicit @mention or a reply to one of the bot's own messages (a follow-up
+    needs no re-mention). ``message.guild is None`` is the DM discriminator."""
+    if message.guild is None:
+        return True
+    mentioned = any(user.id == bot_user_id for user in message.mentions)
+    return mentioned or replying_to_self(message, bot_user_id)
+
+
 async def resolve_parent(message: discord.Message) -> discord.Message | None:
     """The valid parent ``message`` replies to, or ``None`` if it isn't a reply or the parent
     was deleted (a ``NotFound`` is the reply chain's natural end).

--- a/tests/frontends/discord/test_history.py
+++ b/tests/frontends/discord/test_history.py
@@ -18,12 +18,16 @@ from petbot.frontends.discord.history import (
     _describe_card,
     aiter_until_none,
     atake,
+    is_conversational_trigger,
     reconstruct,
     replying_to_self,
     resolve_parent,
     strip_self_mention,
     to_turns,
 )
+
+#: Sentinel for "this message is in a guild" (``message.guild is None`` marks a DM).
+_A_GUILD = object()
 
 
 class _FakeResp:
@@ -77,12 +81,17 @@ class FakeMessage:
         embeds: tuple[discord.Embed, ...] = (),
         reference: FakeRef | None = None,
         channel: FakeChannel | None = None,
+        guild: object | None = _A_GUILD,
+        mentions: tuple[FakeAuthor, ...] = (),
     ) -> None:
         self.author = author
         self.content = content
         self.embeds = list(embeds)
         self.reference = reference
         self.channel = channel or FakeChannel()
+        # `guild is None` marks a DM; `mentions` are the users the message pings.
+        self.guild = guild
+        self.mentions = list(mentions)
 
 
 # --- generic async combinators ------------------------------------------------
@@ -169,6 +178,34 @@ def test_replying_to_self_reads_only_the_inlined_copy() -> None:
     assert replying_to_self(FakeMessage(author=FakeAuthor(2, "Alice")), 1) is False  # type: ignore[arg-type]
     plain_reply = FakeMessage(author=FakeAuthor(2, "Alice"), reference=FakeRef(100))
     assert replying_to_self(plain_reply, 1) is False  # type: ignore[arg-type]
+
+
+def test_dm_always_triggers_without_a_mention() -> None:
+    # A DM (guild is None) is addressed to the bot even with no @mention — the fix for a
+    # DM that was silently dropped for lacking a mention.
+    dm = FakeMessage(author=FakeAuthor(2, "Alice"), content="hey", guild=None)
+    assert is_conversational_trigger(dm, 1) is True  # type: ignore[arg-type]
+
+
+def test_guild_message_triggers_only_on_mention_or_reply_to_self() -> None:
+    plain = FakeMessage(author=FakeAuthor(2, "Alice"), content="just chatting")
+    assert is_conversational_trigger(plain, 1) is False  # type: ignore[arg-type]  # no ping, no reply
+
+    mentioned = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@1> hi", mentions=(FakeAuthor(1, "PetBot"),)
+    )
+    assert is_conversational_trigger(mentioned, 1) is True  # type: ignore[arg-type]
+
+    other_ping = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="<@3> hi", mentions=(FakeAuthor(3, "Bob"),)
+    )
+    assert is_conversational_trigger(other_ping, 1) is False  # type: ignore[arg-type]  # not us
+
+    bot_reply = FakeMessage(author=FakeAuthor(1, "PetBot"), content="hi")
+    reply_to_self = FakeMessage(
+        author=FakeAuthor(2, "Alice"), content="thanks", reference=FakeRef(100, resolved=bot_reply)
+    )
+    assert is_conversational_trigger(reply_to_self, 1) is True  # type: ignore[arg-type]  # follow-up
 
 
 # --- resolving one hop --------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1614,7 +1614,7 @@ requires-dist = [
     { name = "petbot", extras = ["observability"], marker = "extra == 'discord'" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6" },
     { name = "pydantic", specifier = ">=2.13" },
-    { name = "pydantic-ai-slim", extras = ["bedrock", "openai"], marker = "extra == 'compute-core'", specifier = ">=1.107" },
+    { name = "pydantic-ai-slim", extras = ["bedrock", "openai"], marker = "extra == 'compute-core'", specifier = ">=1.107,<2" },
     { name = "pydantic-settings", marker = "extra == 'compute-core'", specifier = ">=2.14" },
     { name = "pydantic-settings", marker = "extra == 'compute-music'", specifier = ">=2.14" },
     { name = "pydantic-settings", marker = "extra == 'discord'", specifier = ">=2.14" },


### PR DESCRIPTION
## Summary

Two bugs a friend hit while DMing the bot, triaged from AWS telemetry (CloudWatch `/aws/lambda/petbot-core` + X-Ray), not guessed from code.

### Bug 1 — a DM without an @mention was silently dropped
`PetBot.on_message` only engaged on a guild @mention or a reply to one of the bot's own messages. A DM is always addressed to the bot, so it needs no trigger — but the guard dropped it and the request never reached the compute service (zero Lambda logs for it, consistent with an edge-side drop).

**Fix:** extract the decision into a pure `is_conversational_trigger` — DM (`message.guild is None`) always triggers; a guild message still requires a mention or a reply-to-self. Unit-tested directly (the codebase pattern of testing pure helpers against fakes).

### Bug 2 — every @mention crashed with "Something went wrong handling that request."
That string is `_CRASHED` from `platform/serve.py`, returned when the process raises. The Lambda log for the friend's two attempts:

```
process/chat.py:105  self._model = build_model(self._settings)
process/model.py:63  return replace(openai_model_profile(model_name), json_schema_transformer=_GeminiToolSchema)
TypeError: replace() should be called on dataclass instances
```

**Root cause — dependency drift, not the Gemma pin itself:**
- `pyproject.toml` floored `pydantic-ai-slim>=1.107` with no upper cap.
- `Dockerfile.lambda` installed `.[compute-core]` fresh, **ignoring `uv.lock`**, so a rebuild (image dated 2026-07-01) floated the dep to 2.x.
- In pydantic-ai 2.x, `openai_model_profile()` returns a `dict`, not a dataclass, so `dataclasses.replace(...)` at `model.py:63` throws. Reproduced locally against `pydantic-ai-slim==2.3.0`.
- CI stayed green because it installs from the lock (1.107.0), where the profile is a dataclass.

**Fix — close the drift so prod resolves exactly what CI tests:**
- Cap `pydantic-ai-slim>=1.107,<2` in `pyproject.toml` (+ refreshed `uv.lock`).
- Build the Lambda image from the lockfile: `uv export --frozen --no-emit-project --extra compute-core` → install the pinned set, then the project `--no-deps`.
- `process/model.py` is left unchanged — it is correct under the locked 1.107.

## Testing
- `uv run pytest` — 136 passed
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy` — clean
- `uv run lint-imports` — 6 contracts kept
- Synced env pins `pydantic-ai 1.107.0`; reproduced the crash on 2.3.0 out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VwWQXrGedDysAPZUBoh1R

---
_Generated by [Claude Code](https://claude.ai/code/session_014VwWQXrGedDysAPZUBoh1R)_